### PR TITLE
Fix error messages being cut off

### DIFF
--- a/src/main/kotlin/com/toasttab/pulseman/state/UserFeedback.kt
+++ b/src/main/kotlin/com/toasttab/pulseman/state/UserFeedback.kt
@@ -30,7 +30,7 @@ class UserFeedback(
     }
 
     fun setUserFeedback(text: String) {
-        userFeedback.add("${timeNow()}: $text${System.lineSeparator()}")
+        userFeedback.add("${timeNow()}: $text")
     }
 
     private fun onUserFeedbackClear() {

--- a/src/main/kotlin/com/toasttab/pulseman/view/UserFeedbackUI.kt
+++ b/src/main/kotlin/com/toasttab/pulseman/view/UserFeedbackUI.kt
@@ -61,17 +61,11 @@ fun userFeedbackUI(
                     .fillMaxWidth(fraction = 0.95f)
             ) {
                 userFeedback.forEach {
-                    Text(
-                        text = it,
-                        overflow = TextOverflow.Ellipsis,
-                        softWrap = false,
-                        maxLines = 1
-                    )
+                    Text(text = it, softWrap = true)
                 }
             }
             Column(
-                modifier = Modifier
-                    .align(alignment = Alignment.CenterVertically)
+                modifier = Modifier.align(alignment = Alignment.CenterVertically)
             ) {
                 IconButton(
                     onClick = { onUserFeedbackClear() },


### PR DESCRIPTION
Error messages greater than one line where getting cut off.
They would show as follows
![image](https://user-images.githubusercontent.com/46324995/173371489-a7e2acff-eb85-4f9b-90a0-b36803b2e3ea.png)

This change has it working again
![image](https://user-images.githubusercontent.com/46324995/173371669-9a097913-ac91-486b-88ab-fdb344982f61.png)

The only problem is that trying to copy multiple lines no longer includes the line break, this bug will have to be revisited.
Copy pasting the following
![image](https://user-images.githubusercontent.com/46324995/173371911-d40e683b-0c7a-4fc1-8af8-816289a27224.png)
Will now give you this
```15:05:58: No class generated to send15:06:02: No class generated to send```