### PR TITLE
Show error messages in compiled messages

### DIFF
--- a/src/main/kotlin/com/toasttab/pulseman/scripting/KotlinScripting.kt
+++ b/src/main/kotlin/com/toasttab/pulseman/scripting/KotlinScripting.kt
@@ -58,7 +58,7 @@ object KotlinScripting {
             setUserFeedback(SUCCESSFULLY_COMPILED_CLASS)
             return classToGenerate.serialize(generatedClass)
         } catch (ex: Throwable) {
-            setUserFeedback("$EXCEPTION:\n$ex")
+            setUserFeedback(ex.message ?: "Unknown")
         }
         return null
     }


### PR DESCRIPTION
Show user feedback can only display a single line. So the new line character ENDS feedback

This change shows the error message

Here are some errors I created
<img width="745" alt="Screen Shot 2022-06-13 at 3 07 03 PM" src="https://user-images.githubusercontent.com/101126316/173372647-647be6d5-66f4-4a6a-a794-d4db19dea77c.png">

