### PR TITLE
Add base64 serialization support

### DIFF
--- a/src/main/kotlin/com/toasttab/pulseman/entities/CharacterSet.kt
+++ b/src/main/kotlin/com/toasttab/pulseman/entities/CharacterSet.kt
@@ -17,13 +17,13 @@ package com.toasttab.pulseman.entities
 
 // Taken from import java.nio.charset.Charset
 enum class CharacterSet(val charSet: String) {
+    BASE64("Base64"),
     US_ASCII("US-ASCII"),
     ISO_8859_1("ISO-8859-1"),
     UTF_8("UTF-8"),
     UTF_16BE("UTF-16BE"),
     UTF_16LE("UTF-16LE"),
-    UTF_16("UTF-16"),
-    BASE64("Base64");
+    UTF_16("UTF-16");
 
     companion object {
         private val charSetMapping = values().associateBy { it.charSet }

--- a/src/main/kotlin/com/toasttab/pulseman/entities/CharacterSet.kt
+++ b/src/main/kotlin/com/toasttab/pulseman/entities/CharacterSet.kt
@@ -22,7 +22,8 @@ enum class CharacterSet(val charSet: String) {
     UTF_8("UTF-8"),
     UTF_16BE("UTF-16BE"),
     UTF_16LE("UTF-16LE"),
-    UTF_16("UTF-16");
+    UTF_16("UTF-16"),
+    BASE64("Base64");
 
     companion object {
         private val charSetMapping = values().associateBy { it.charSet }

--- a/src/main/kotlin/com/toasttab/pulseman/pulsar/handlers/text/TextHandler.kt
+++ b/src/main/kotlin/com/toasttab/pulseman/pulsar/handlers/text/TextHandler.kt
@@ -38,7 +38,7 @@ data class TextHandler(val characterSet: CharacterSet) : PulsarMessage {
             }
 
         } catch (ex: Throwable) {
-            "$EXCEPTION:$ex"
+            "$EXCEPTION: $ex"
         }
     }
 

--- a/src/main/kotlin/com/toasttab/pulseman/pulsar/handlers/text/TextHandler.kt
+++ b/src/main/kotlin/com/toasttab/pulseman/pulsar/handlers/text/TextHandler.kt
@@ -19,17 +19,24 @@ import com.toasttab.pulseman.AppStrings.EXCEPTION
 import com.toasttab.pulseman.entities.CharacterSet
 import com.toasttab.pulseman.pulsar.handlers.PulsarMessage
 import java.nio.charset.Charset
+import java.util.Base64
 
 data class TextHandler(val characterSet: CharacterSet) : PulsarMessage {
-    private val convertedCharset = Charset.forName(characterSet.charSet)
     override fun serialize(cls: Any): ByteArray {
         val msg = cls as String
-        return msg.toByteArray(convertedCharset)
+        return when (characterSet) {
+            CharacterSet.BASE64 -> Base64.getDecoder().decode(msg)
+            else -> msg.toByteArray(Charset.forName(characterSet.charSet))
+        }
     }
 
     override fun deserialize(bytes: ByteArray): Any {
         return try {
-            String(bytes, convertedCharset)
+            when (characterSet) {
+                CharacterSet.BASE64 -> Base64.getEncoder().encodeToString(bytes)
+                else -> String(bytes, Charset.forName(characterSet.charSet))
+            }
+
         } catch (ex: Throwable) {
             "$EXCEPTION:$ex"
         }

--- a/src/test/kotlin/com/toasttab/pulseman/pulsar/PulsarTextMessageITest.kt
+++ b/src/test/kotlin/com/toasttab/pulseman/pulsar/PulsarTextMessageITest.kt
@@ -95,6 +95,7 @@ class PulsarTextMessageITest : PulsarITestSupport() {
             Arguments.of(CharacterSet.UTF_16, utf16Bytes, "Test input UTF_16, $ €"),
             Arguments.of(CharacterSet.UTF_16BE, utf16BEBytes, "Test input UTF_16BE, $ €"),
             Arguments.of(CharacterSet.UTF_16LE, utf16LEBytes, "Test input UTF_16LE, $ €"),
+            Arguments.of(CharacterSet.BASE64, base64Bytes, "Test input Base64, $"),
         )
     }
 
@@ -103,6 +104,12 @@ class PulsarTextMessageITest : PulsarITestSupport() {
         private val utf8Bytes = ubyteArrayOf(
             0x54U, 0x65U, 0x73U, 0x74U, 0x20U, 0x69U, 0x6eU, 0x70U, 0x75U, 0x74U, 0x20U, 0x55U, 0x54U, 0x46U, 0x5fU,
             0x38U, 0x2cU, 0x20U, 0x24U, 0x20U, 0xe2U, 0x82U, 0xacU
+        ).asByteArray()
+
+        @OptIn(ExperimentalUnsignedTypes::class)
+        private val base64Bytes = ubyteArrayOf(
+            0x54U, 0x65U, 0x73U, 0x74U, 0x20U, 0x69U, 0x6eU, 0x70U, 0x75U, 0x74U, 0x20U, 0x49U, 0x53U, 0x4fU, 0x5fU,
+            0x38U, 0x38U, 0x35U, 0x39U, 0x5fU, 0x31U, 0x2cU, 0x20U, 0x24U
         ).asByteArray()
 
         @OptIn(ExperimentalUnsignedTypes::class)


### PR DESCRIPTION
It would be nice to get base64 supported as a text serialization mechanism to send and receive - occasionally things like the protobuf bytestream are important to look at in a more "raw" format to play with later.