### PR TITLE
Create separate jar loaders for Protokt and standard Proto usage.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,6 +115,7 @@ jobs:
           command: java -version
       - run:
           name: "Create DMG"
+          no_output_timeout: 30m
           command: ./gradlew packageDmg --stacktrace
       - run:
           name: "Copy dmg create logs to workspace"
@@ -125,6 +126,7 @@ jobs:
           command: cp ~/project/build/compose/binaries/main/dmg/* artifacts/
       - run:
           name: "Notarize DMG"
+          no_output_timeout: 30m
           command: ./gradlew notarizeDmg
       - write_cache_mac
       - persist_to_workspace:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -83,8 +83,8 @@ dependencies {
     implementation("org.slf4j:slf4j-nop:$sl4jNoop")
 
     /**
-     * Directly importing the pulsar-client jar as it is causing an issue with signing Mac apps, something to do with
-     * the compressed size being mismatched. They must be somehow modifying the jar before publishing.
+     * The pulsar-client jar is causing an issue with signing Mac apps, something to do with
+     * the compressed size being mismatched.
      *  Cause: invalid entry compressed size (expected 5232 but got 5227 bytes)
      * Stripping all META-INF from the import via gradle task for now to make it work.
      * This happened with multiple versions of the import.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -95,7 +95,8 @@ dependencies {
 
     /**
      * The protokt version of proto-google-common-protos uses the same package and class names.
-     * They are only being downloaded and packaged with the release they will not be automatically loaded into the classloader.
+     * They are only being downloaded and packaged with the release they will not be automatically loaded into the
+     * classloader.
      * They will be added to separate classloaders one for protoKT protos and one for standard protos.
      */
     compileOnly("com.google.api.grpc:proto-google-common-protos:$googleCommonProtos")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -181,7 +181,7 @@ val stripMetaInfTask: TaskProvider<Task> = tasks.register("stripMetaInf") {
 }
 
 /**
- * STRIP META-INF Part 3: Make the stripped jar an implementation dependency on the app.
+ * STRIP META-INF Part 4: Make the stripped jar an implementation dependency on the app.
  */
 val importPulsarClientTask: TaskProvider<Task> = tasks.register("importPulsarClientTask") {
     dependsOn(stripMetaInfTask)
@@ -198,7 +198,7 @@ tasks.named("processResources") {
 }
 
 /**
- * STRIP META-INF Part 0: Kick off flow based
+ * STRIP META-INF Part 0: Kick off flow
  */
 tasks.named("assemble") {
     dependsOn(importPulsarClientTask)

--- a/src/main/kotlin/com/toasttab/pulseman/jars/JarLoader.kt
+++ b/src/main/kotlin/com/toasttab/pulseman/jars/JarLoader.kt
@@ -25,8 +25,12 @@ import java.net.URLClassLoader
  * TODO there may be a better way to do this with ModuleLayer
  * https://docs.oracle.com/javase/9/docs/api/java/lang/ModuleLayer.html
  */
-class JarLoader(urls: Array<URL?>, parent: ClassLoader) : URLClassLoader(urls, parent) {
+class JarLoader(urls: Array<URL?>) : URLClassLoader(urls, JarLoader::class.java.classLoader) {
     fun addJar(url: URL) {
         super.addURL(url)
+    }
+
+    fun copy(): JarLoader {
+        return JarLoader(this.urLs)
     }
 }

--- a/src/main/kotlin/com/toasttab/pulseman/jars/RunTimeJarLoader.kt
+++ b/src/main/kotlin/com/toasttab/pulseman/jars/RunTimeJarLoader.kt
@@ -43,9 +43,20 @@ object RunTimeJarLoader {
         Thread.currentThread().contextClassLoader = jarLoader
     }
 
-    private fun newJarLoader() = JarLoader(arrayOfNulls(0), JarLoader::class.java.classLoader)
+    private fun newJarLoader() = JarLoader(arrayOfNulls(0))
+
     private var jarLoader = newJarLoader()
 
     val loader: JarLoader
         get() = jarLoader
+
+    val googleJarLoader: JarLoader
+        get() = jarLoader.copy().also {
+            SeperatedJars.addGoogleJars(it)
+        }
+
+    val protoKTJarLoader: JarLoader
+        get() = jarLoader.copy().also {
+            SeperatedJars.addProtoKTJars(it)
+        }
 }

--- a/src/main/kotlin/com/toasttab/pulseman/jars/SeperatedJars.kt
+++ b/src/main/kotlin/com/toasttab/pulseman/jars/SeperatedJars.kt
@@ -22,6 +22,7 @@ import java.net.URL
  * separate classloaders to prevent conflicts with these Jars
  */
 object SeperatedJars {
+    // Gradle task copies and names these jars to the resource folder
     private const val googleCommon = "proto-google-common-protos-original.jar"
     private const val protoKTCommon = "proto-google-common-protos-protoKT.jar"
     private const val protoKTCommonLite = "proto-google-common-protos-lite-protoKT.jar"

--- a/src/main/kotlin/com/toasttab/pulseman/jars/SeperatedJars.kt
+++ b/src/main/kotlin/com/toasttab/pulseman/jars/SeperatedJars.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2021 Toast Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.toasttab.pulseman.jars
+
+import java.net.URL
+
+/**
+ * protoKT has overridden the package path for types like google.type.Money we need
+ * separate classloaders to prevent conflicts with these Jars
+ */
+object SeperatedJars {
+    private const val googleCommon = "proto-google-common-protos-original.jar"
+    private const val protoKTCommon = "proto-google-common-protos-protoKT.jar"
+    private const val protoKTCommonLite = "proto-google-common-protos-lite-protoKT.jar"
+
+    private val googleJars = listOf(getJarURL(googleCommon))
+    private val protoKTJars = listOf(getJarURL(protoKTCommon), getJarURL(protoKTCommonLite))
+
+    private fun getJarURL(resourcePath: String): URL {
+        val contextClassLoader = Thread.currentThread().contextClassLoader!!
+        return contextClassLoader.getResource(resourcePath)!!
+    }
+
+    fun addGoogleJars(jarLoader: JarLoader) {
+        googleJars.forEach {
+            jarLoader.addJar(it)
+        }
+    }
+
+    fun addProtoKTJars(jarLoader: JarLoader) {
+        protoKTJars.forEach {
+            jarLoader.addJar(it)
+        }
+    }
+}

--- a/src/main/kotlin/com/toasttab/pulseman/pulsar/handlers/PulsarMessageClassInfo.kt
+++ b/src/main/kotlin/com/toasttab/pulseman/pulsar/handlers/PulsarMessageClassInfo.kt
@@ -16,6 +16,7 @@
 package com.toasttab.pulseman.pulsar.handlers
 
 import com.toasttab.pulseman.entities.ClassInfo
+import com.toasttab.pulseman.jars.JarLoader
 import java.io.File
 
 /**
@@ -34,4 +35,14 @@ interface PulsarMessageClassInfo : PulsarMessage, ClassInfo {
      * @return A string template for the class.
      */
     fun generateClassTemplate(): String
+
+    /**
+     * protoKT has overridden the package path for types like google.type.Money we need
+     * separate classloaders to prevent conflicts between these imports
+     *     com.google.api.grpc:proto-google-common-protos
+     *     com.toasttab.protokt.thirdparty:proto-google-common-protos
+     *
+     * @return JarLoader containing the jar needed to generate a class using kotlin scripting
+     */
+    fun getJarLoader(): JarLoader
 }

--- a/src/main/kotlin/com/toasttab/pulseman/pulsar/handlers/protobuf/GeneratedMessageV3Handler.kt
+++ b/src/main/kotlin/com/toasttab/pulseman/pulsar/handlers/protobuf/GeneratedMessageV3Handler.kt
@@ -33,8 +33,7 @@ data class GeneratedMessageV3Handler(override val cls: Class<out GeneratedMessag
 
     override fun deserialize(bytes: ByteArray): Any {
         return try {
-            RunTimeJarLoader
-                .googleJarLoader
+            getJarLoader()
                 .loadClass(cls.name)
                 .getDeclaredMethod(PARSE_METHOD, ByteArray::class.java)
                 .invoke(null, bytes)

--- a/src/main/kotlin/com/toasttab/pulseman/pulsar/handlers/protobuf/GeneratedMessageV3Handler.kt
+++ b/src/main/kotlin/com/toasttab/pulseman/pulsar/handlers/protobuf/GeneratedMessageV3Handler.kt
@@ -18,6 +18,7 @@ package com.toasttab.pulseman.pulsar.handlers.protobuf
 import com.google.protobuf.GeneratedMessageV3
 import com.google.protobuf.util.JsonFormat
 import com.toasttab.pulseman.AppStrings.EXCEPTION
+import com.toasttab.pulseman.jars.JarLoader
 import com.toasttab.pulseman.jars.RunTimeJarLoader
 import com.toasttab.pulseman.pulsar.handlers.PulsarMessageClassInfo
 import java.io.File
@@ -33,7 +34,7 @@ data class GeneratedMessageV3Handler(override val cls: Class<out GeneratedMessag
     override fun deserialize(bytes: ByteArray): Any {
         return try {
             RunTimeJarLoader
-                .loader
+                .googleJarLoader
                 .loadClass(cls.name)
                 .getDeclaredMethod(PARSE_METHOD, ByteArray::class.java)
                 .invoke(null, bytes)
@@ -51,6 +52,10 @@ data class GeneratedMessageV3Handler(override val cls: Class<out GeneratedMessag
         val import = "import $fullName"
 
         return "$import\n\n$className\n\t.newBuilder()\n\t//TODO set values\n\t.build()"
+    }
+
+    override fun getJarLoader(): JarLoader {
+        return RunTimeJarLoader.googleJarLoader
     }
 
     companion object {

--- a/src/main/kotlin/com/toasttab/pulseman/pulsar/handlers/protobuf/KTMessageHandler.kt
+++ b/src/main/kotlin/com/toasttab/pulseman/pulsar/handlers/protobuf/KTMessageHandler.kt
@@ -35,11 +35,12 @@ data class KTMessageHandler(override val cls: Class<out KtMessage>, override val
 
     override fun deserialize(bytes: ByteArray): Any {
         return try {
-            ThreadUtil.run(RunTimeJarLoader.protoKTJarLoader) {
+            val jarLoader = RunTimeJarLoader.protoKTJarLoader
+            ThreadUtil.run(jarLoader) {
                 cls.declaredClasses
                     .first { it.name.contains(DESERIALIZER_CLASS) }
                     .let {
-                        val deserializer = (it.kotlin.objectInstance as KtDeserializer<*>)
+                        val deserializer = jarLoader.loadClass(it.name).kotlin.objectInstance as KtDeserializer<*>
                         deserializer.deserialize(bytes)
                     }
             }

--- a/src/main/kotlin/com/toasttab/pulseman/state/protocol/protobuf/ProtobufState.kt
+++ b/src/main/kotlin/com/toasttab/pulseman/state/protocol/protobuf/ProtobufState.kt
@@ -68,7 +68,6 @@ class ProtobufState(
     )
 
     private val sendMessage = SendProtobufMessage(
-        appState = appState,
         setUserFeedback = setUserFeedback,
         selectedClass = protobufSelector.selectedClass,
         pulsarSettings = pulsarSettings,

--- a/src/main/kotlin/com/toasttab/pulseman/state/protocol/protobuf/SendProtobufMessage.kt
+++ b/src/main/kotlin/com/toasttab/pulseman/state/protocol/protobuf/SendProtobufMessage.kt
@@ -17,7 +17,6 @@ package com.toasttab.pulseman.state.protocol.protobuf
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
-import com.toasttab.pulseman.AppState
 import com.toasttab.pulseman.AppStrings.FAILED_TO_SEND_MESSAGE
 import com.toasttab.pulseman.AppStrings.GENERATED_CODE_TEMPLATE
 import com.toasttab.pulseman.AppStrings.NO_CLASS_SELECTED
@@ -39,7 +38,6 @@ import org.fife.ui.rsyntaxtextarea.SyntaxConstants
 import org.fife.ui.rtextarea.RTextScrollPane
 
 class SendProtobufMessage(
-    val appState: AppState,
     val setUserFeedback: (String) -> Unit,
     val selectedClass: SingleSelection<PulsarMessageClassInfo>,
     val pulsarSettings: PulsarSettings,

--- a/src/main/kotlin/com/toasttab/pulseman/util/FileDialog.kt
+++ b/src/main/kotlin/com/toasttab/pulseman/util/FileDialog.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2021 Toast Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.toasttab.pulseman.util
 
 import java.awt.Frame

--- a/src/main/kotlin/com/toasttab/pulseman/util/ThreadUtil.kt
+++ b/src/main/kotlin/com/toasttab/pulseman/util/ThreadUtil.kt
@@ -15,7 +15,18 @@
 
 package com.toasttab.pulseman.util
 
-enum class FileDialogMode {
-    LOAD,
-    SAVE
+import com.toasttab.pulseman.jars.JarLoader
+import java.util.concurrent.CompletableFuture
+
+/***
+ * This is to isolate any modifications of the contextClassLoader to a single thread and
+ * prevent any risk of multiple operations interfering with each-other.
+ */
+object ThreadUtil {
+    fun <T> run(jarLoader: JarLoader, block: () -> T): T {
+        return CompletableFuture.supplyAsync {
+            Thread.currentThread().contextClassLoader = jarLoader
+            block()
+        }.get()
+    }
 }

--- a/src/test/kotlin/com/toasttab/pulseman/MultipleTypesPulsarMessage.kt
+++ b/src/test/kotlin/com/toasttab/pulseman/MultipleTypesPulsarMessage.kt
@@ -15,6 +15,7 @@
 
 package com.toasttab.pulseman
 
+import com.toasttab.pulseman.jars.JarLoader
 import com.toasttab.pulseman.pulsar.handlers.DefaultMapper
 import com.toasttab.pulseman.pulsar.handlers.PulsarMessageClassInfo
 import java.io.File
@@ -29,4 +30,8 @@ class MultipleTypesPulsarMessage(override val cls: Class<out MultipleTypes>, ove
         DefaultMapper.mapper.writerWithDefaultPrettyPrinter().writeValueAsString(cls)
 
     override fun generateClassTemplate(): String = "MultipleTypes()"
+
+    override fun getJarLoader(): JarLoader {
+        return JarLoader(arrayOfNulls(0))
+    }
 }


### PR DESCRIPTION
protoKT has overridden the package path for types like google.type.Money, the following imports are causing path conflicts

```
com.google.api.grpc:proto-google-common-protos
com.toasttab.protokt.thirdparty:proto-google-common-protos
```

To solve this I have  
- Created seperate class loaders
  - One for standard proto messages that has `com.google.api.grpc:proto-google-common-protos`
  - One for ProtoKT generated messages that has `com.toasttab.protokt.thirdparty:proto-google-common-protos`
- Updated gradle to load these imports to the resources folder only and not into the apps class loader, this way they can be added to separate classloaders.
- Create separate threads for compiling requests and deserialising responses, this will allow the separate class loader to be loaded without causing issues to other tabs. 

Also as part of this I have automated the stripping of the META-INF info from the pulsar client that was causing mac signing issues. This is now done through a gradle task.