### PR TITLE
Alert user that they may have a conflicting jar added

### DIFF
--- a/src/main/kotlin/com/toasttab/pulseman/AppState.kt
+++ b/src/main/kotlin/com/toasttab/pulseman/AppState.kt
@@ -33,9 +33,12 @@ import com.toasttab.pulseman.pulsar.filters.protobuf.GeneratedMessageV3Filter
 import com.toasttab.pulseman.pulsar.filters.protobuf.KTMessageFilter
 import com.toasttab.pulseman.pulsar.handlers.PulsarAuthHandler
 import com.toasttab.pulseman.pulsar.handlers.PulsarMessageClassInfo
+import com.toasttab.pulseman.state.GlobalFeedback
 import com.toasttab.pulseman.state.TabHolder
 
 class AppState {
+    val globalFeedback = GlobalFeedback()
+
     val pulsarMessageJars: JarManager<PulsarMessageClassInfo> = JarManager(
         loadedClasses = LoadedClasses(
             classFilters = listOf(
@@ -44,7 +47,8 @@ class AppState {
                 GeneratedMessageV3Filter()
             )
         ),
-        jarFolderName = MESSAGE_JAR_FOLDER
+        jarFolderName = MESSAGE_JAR_FOLDER,
+        globalFeedback = globalFeedback
     )
 
     val authJars: JarManager<PulsarAuthHandler> = JarManager(
@@ -54,14 +58,16 @@ class AppState {
                 AuthClassFilter()
             )
         ),
-        jarFolderName = AUTH_JAR_FOLDER
+        jarFolderName = AUTH_JAR_FOLDER,
+        globalFeedback = globalFeedback
     )
 
     val dependencyJars: JarManager<ClassInfo> = JarManager(
         loadedClasses = LoadedClasses(
             classFilters = emptyList()
         ),
-        jarFolderName = DEPENDENCY_JAR_FOLDER
+        jarFolderName = DEPENDENCY_JAR_FOLDER,
+        globalFeedback = globalFeedback
     )
 
     private val jarManagers = listOf(pulsarMessageJars, authJars, dependencyJars)
@@ -69,6 +75,7 @@ class AppState {
     val requestTabs = TabHolder(this)
 
     fun loadFile(loadDefault: Boolean) {
+        globalFeedback.reset()
         FileManagement.getProjectFile(loadDefault)?.let { projectFile ->
             jarManagers.forEach { it.deleteAllJars() }
             val newTabs =

--- a/src/main/kotlin/com/toasttab/pulseman/AppStrings.kt
+++ b/src/main/kotlin/com/toasttab/pulseman/AppStrings.kt
@@ -38,6 +38,7 @@ object AppStrings {
     const val COLLAPSE = "Collapse"
     const val COMPILE = "Compile"
     const val COMPILING = "Compiling..."
+    const val CONFLICT_WARNING = "WARNING file may cause conflicts"
     const val CONNECTION_CLOSED = "Connection closed"
     const val CONVERT = "Convert"
     const val CONVERTING = "Converting"

--- a/src/main/kotlin/com/toasttab/pulseman/state/GlobalFeedback.kt
+++ b/src/main/kotlin/com/toasttab/pulseman/state/GlobalFeedback.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2021 Toast Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.toasttab.pulseman.state
+
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.snapshots.SnapshotStateList
+
+class GlobalFeedback {
+    private val storedFeedback: SnapshotStateList<String> = mutableStateListOf()
+    private val userFeedbackSet = mutableSetOf<UserFeedback>()
+
+    fun registerCallback(userFeedback: UserFeedback, newTab: Boolean) {
+        synchronized(this) {
+            userFeedbackSet.add(userFeedback)
+            if (!newTab) {
+                replayStoredFeedback(userFeedback)
+            }
+        }
+    }
+
+    fun closeCallback(userFeedback: UserFeedback) {
+        synchronized(this) {
+            userFeedbackSet.remove(userFeedback)
+        }
+    }
+
+    fun set(text: String) {
+        synchronized(this) {
+            if (userFeedbackSet.isEmpty()) {
+                storedFeedback.add(text)
+            } else {
+                storedFeedback.clear()
+                setUserFeedback(text)
+            }
+        }
+    }
+
+    fun reset() {
+        synchronized(this) {
+            userFeedbackSet.clear()
+            storedFeedback.clear()
+        }
+    }
+
+    private fun replayStoredFeedback(userFeedback: UserFeedback) {
+        storedFeedback.forEach { feedback ->
+            userFeedback.set(feedback)
+        }
+    }
+
+    private fun setUserFeedback(text: String) {
+        userFeedbackSet.forEach { userFeedback ->
+            userFeedback.set(text)
+        }
+    }
+}

--- a/src/main/kotlin/com/toasttab/pulseman/state/TabHolder.kt
+++ b/src/main/kotlin/com/toasttab/pulseman/state/TabHolder.kt
@@ -33,7 +33,8 @@ class TabHolder(private val appState: AppState) {
             appState = appState,
             selection = selection,
             close = ::close,
-            initialMessage = initialMessage
+            initialMessage = initialMessage,
+            newTab = true
         )
         tabState.add(tab)
         tab.activate()
@@ -53,7 +54,8 @@ class TabHolder(private val appState: AppState) {
                 appState = appState,
                 selection = selection,
                 close = ::close,
-                initialSettings = it
+                initialSettings = it,
+                newTab = false
             )
             tabState.add(tab)
         }
@@ -70,7 +72,8 @@ class TabHolder(private val appState: AppState) {
                     currentTabValues.copy(
                         tabName = currentTabValues.tabName + " - $COPY"
                     )
-                }
+                },
+                newTab = true
             )
             tabState.add(copiedTab)
             copiedTab.activate()

--- a/src/main/kotlin/com/toasttab/pulseman/state/UserFeedback.kt
+++ b/src/main/kotlin/com/toasttab/pulseman/state/UserFeedback.kt
@@ -23,17 +23,26 @@ import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
 class UserFeedback(
-    private val userFeedback: SnapshotStateList<String> = mutableStateListOf()
+    private val globalFeedback: GlobalFeedback,
+    private val userFeedback: SnapshotStateList<String> = mutableStateListOf(),
+    newTab: Boolean
 ) {
-    companion object {
-        private val formatter: DateTimeFormatter = DateTimeFormatter.ofPattern("HH:mm:ss")
+    init {
+        globalFeedback.registerCallback(
+            userFeedback = this,
+            newTab = newTab
+        )
     }
 
-    fun setUserFeedback(text: String) {
+    override fun close() {
+        globalFeedback.closeCallback(this)
+    }
+
+    fun set(text: String) {
         userFeedback.add("${timeNow()}: $text")
     }
 
-    private fun onUserFeedbackClear() {
+    private fun clear() {
         userFeedback.clear()
     }
 
@@ -42,7 +51,11 @@ class UserFeedback(
     fun ui(): @Composable () -> Unit = {
         userFeedbackUI(
             userFeedback = userFeedback,
-            onUserFeedbackClear = ::onUserFeedbackClear
+            onUserFeedbackClear = this::clear
         )
+    }
+
+    companion object {
+        private val formatter: DateTimeFormatter = DateTimeFormatter.ofPattern("HH:mm:ss")
     }
 }

--- a/src/main/kotlin/com/toasttab/pulseman/view/UserFeedbackUI.kt
+++ b/src/main/kotlin/com/toasttab/pulseman/view/UserFeedbackUI.kt
@@ -39,7 +39,7 @@ import com.toasttab.pulseman.AppTheme
 
 /**
  * This views shows a scrollable history of events in the current tab.
- * It is used by passing the setUserFeedback function to all views that need it.
+ * It is used by passing the set function to all views that need it.
  */
 @Composable
 fun userFeedbackUI(


### PR DESCRIPTION
The `protoKT` implementation overrides the package path for the standard `proto-google-common-protos`  jar.
A new fix was added to the recent `pulseman` release to allow the`protoKT` and standard `common-protos` jars to work in the same project.
The fix involves custom jar loaders for each protobuf type.
However if you import the `common-protos` directly into your project it can cause issues and override the correct `common-protos` jar.
This PR adds a warning to let a user know when adding potentially problematic jars