### PR TITLE
Upgrade CircleCI mac image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,7 @@ jobs:
 
   mac-build:
     macos:
-      xcode: 13.2.1
+      xcode: 14.3.1
     steps:
       - checkout
       - read_cache_mac
@@ -101,15 +101,6 @@ jobs:
             security default-keychain -s "compose.keychain"
             security unlock-keychain -p "keychain-pass" "compose.keychain"
             security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k keychain-pass
-      - run:
-          name: "Check current java version"
-          command: java -version
-      - run:
-          name: "Install java 17"
-          command: |
-            brew install openjdk@17
-            sudo ln -sfn /usr/local/opt/openjdk@17/libexec/openjdk.jdk /Library/Java/JavaVirtualMachines/openjdk-17.jdk
-            export JAVA_HOME=/Library/Java/JavaVirtualMachines/openjdk-17.jdk/Contents/Home
       - run:
           name: "Check current java version"
           command: java -version


### PR DESCRIPTION
The previous xcode 13.2.1 mac image has been removed from CircleCI support
![image](https://github.com/open-toast/pulseman/assets/46324995/166405c3-7cc4-4a78-bab2-2100552e653e)

Upgrading to latest non beta version 14.3.1.

Also removing Java 17 download step as openJDK is installed by default on this image. This should greatly improve build time.
https://circle-macos-docs.s3.amazonaws.com/image-manifest/v12131/manifest.txt