### PR TITLE
Unique jar loaders per tab

### DIFF
--- a/CREATE-PROJECT.md
+++ b/CREATE-PROJECT.md
@@ -9,11 +9,41 @@ e.g `pulsar+ssl://pulsar.eng.com:6651`
 
 ## Adding jars to a project
 
-The **Jars** button in the top pane allows two types of Jars to be added to the project in the **Auth** or **Other**
-tab.  
+Pulseman allows you to add jars to a project, they are used in serialization/deserialization of messages and when
+setting up authorization.
+
+Separate Jar loaders are used so that each tab can have its unique set of Jars loaded and avoid conflicts. The following
+Jar loaders are used.
+
+- **Common jar loader**: Jars added here will be available project wide in all tabs.
+- **Auth jar loader**: The auth jar loader has the common jar loader as a dependency and has all its jars loaded, it is
+  used by the Auth code to filter for the Authorization class you want to use.
+- **Tab jar loaders**: Each tab has its own jar loader, this is used to load jars that are specific to the tab. This is
+  dependent on the Auth Jar loader.
+
+### Hierarchy of jar loaders
+
+```mermaid
+graph LR
+    CJ[Common Jar Loader] --> AJ(Auth Jar Loader)
+    AJ --> T![Tab 1 Jar Loader]
+    AJ --> T2[Tab 2 Jar Loader]
+    AJ --> T3[Tab 3 Jar Loader]
+```
+
+The **Jars** button in the top pane contains the UI to add jars to the **Common** or **Auth** jar loaders.
+
 If the **Protobuf** serialization option is selected you can add the messaging jars in the **Jars** tab on the bottom
-pane.  
-These are described below. If a jar is added to any tab it is available to the whole project.
+pane.
+
+*ProtoKt* clashes with the namespace of some standard google protobuf imports, to support them working side by side
+in the same project the following gradle imports are loaded manually to the jar loader depending on what type of
+protobuf class is selected for serializing/deserializing.
+
+```
+"com.google.api.grpc:proto-google-common-protos:$googleCommonProtos"
+"com.toasttab.protokt.thirdparty:proto-google-common-protos:$protoktVersion"
+```
 
 ## Set up auth
 
@@ -52,7 +82,7 @@ You can also define an optional key/value map of user-defined properties sent in
 ## Add a generic dependency jar
 
 If you just want to add any dependency for use in serialization/deserialization/auth you can add it to the
-**Dependency Jars** tab
+**Common Jars** tab
 
 ## Searching for topics
 
@@ -60,8 +90,7 @@ If you select the magnifying glass icon and point it at your pulsar set up
 
 e.g `http://localhost:8079`
 
-You can pull down all the topics configured and select which one to use in the project, this only works for
-unauthenticated pulsar setups currently.
+You can pull down all the topics configured and select which one to use in the project.
 
 ## Import your messaging jars
 
@@ -71,14 +100,14 @@ and
 [GeneratedMessageV3](https://www.javadoc.io/static/com.google.protobuf/protobuf-java/3.5.1/com/google/protobuf/GeneratedMessageV3.html)
 protobuf messaging formats are supported. You can import any jars that have classes implementing these interfaces.
 
-More messaging formats will be added in the future.
-
 ### Steps
 
 1. Select the **Jars** tab in any **Protobuf** test tab.
 2. Add any jars containing your message classes.
-3. In the **Class** tab you can now select any class to send a message with or deserialize with.  
-   You can define multiple deserialization classes if you want to try to decode a message into multiple formats.
+3. In the **Class** tab you can now select any class to send a message or deserialize with.
+
+If you want to use the same jars in multiple tabs you can add them to the **Common Jars** tab and reduce project size,
+however be wary of conflicts.
 
 ## Send a message to a topic
 
@@ -107,7 +136,8 @@ Each message decoded will show the pulsar properties of the message also.
 
 1. Import the message jar you wish to deserialize messages with.
 2. In the **Class** tab select a class to decode messages with.
-3. In the **Receive** tab every message on the topic will be decoded with the class selected.
+3. In the **Receive** tab every message on the topic will be decoded with the class selected, if you have a mismatch
+   between the message contents and the selected class you may get garbled output.
 
 ### Text
 

--- a/README.md
+++ b/README.md
@@ -6,10 +6,11 @@ Pulseman (Pulsar manager) is an [Apache Pulsar](https://pulsar.apache.org/) test
 - Subscribe to a Pulsar topic and receive messages
 - Query all topics
 - Import JAR files for serialization and deserialization of messages
+- Import JAR files to decode protobuf messages
 - Import custom authentication JAR files
 - Store and share test collections
 
-Currently, this has only been tested and targeted to work on macOS.
+Currently, this has only been tested and targeted to work on macOS but should work on other platforms.
 
 ## Supported pulsar formats
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -113,6 +113,7 @@ tasks {
     test {
         exclude("**/*IT*.class")
         useJUnitPlatform()
+        dependsOn("createTestJar")
     }
 }
 
@@ -218,6 +219,13 @@ gradle.projectsEvaluated {
     tasks.named("prepareAppResources") {
         dependsOn(copyCommonProtoJarToResources)
     }
+}
+
+tasks.register<Jar>("createTestJar") {
+    archiveBaseName.set("test-class1")
+    archiveVersion.set("") // Prevents appVersion from being appended
+    from(sourceSets.test.get().output)
+    include("com/toasttab/pulseman/testjar/**")
 }
 
 compose.desktop {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -120,6 +120,7 @@ tasks {
 task<Test>("iTest") {
     group = "verification"
     useJUnitPlatform()
+    dependsOn("createTestJar")
 }
 
 ktlint {

--- a/src/main/kotlin/com/toasttab/pulseman/AppState.kt
+++ b/src/main/kotlin/com/toasttab/pulseman/AppState.kt
@@ -37,7 +37,10 @@ import com.toasttab.pulseman.state.TabHolder
 class AppState {
     val globalFeedback = GlobalFeedback()
 
+    // A common Jar Loader, any jars loaded here will be available to all tabs and auth functionality
     private val commonJarLoader = RunTimeJarLoader()
+
+    // This is used for auth operation, inherits the common jars and will be available in all tabs
     private val authJarLoader = RunTimeJarLoader(dependentJarLoader = commonJarLoader)
 
     val commonJars: JarManager<ClassInfo> = JarManager(

--- a/src/main/kotlin/com/toasttab/pulseman/AppState.kt
+++ b/src/main/kotlin/com/toasttab/pulseman/AppState.kt
@@ -48,7 +48,8 @@ class AppState {
         jarFolderName = DEPENDENCY_JAR_FOLDER,
         globalFeedback = globalFeedback,
         runTimeJarLoader = commonJarLoader,
-        originalJarFolderName = null
+        originalJarFolderName = null,
+        tabFileExtension = null
     )
 
     val authJars: JarManager<PulsarAuthHandler> = JarManager(
@@ -62,7 +63,8 @@ class AppState {
         jarFolderName = AUTH_JAR_FOLDER,
         globalFeedback = globalFeedback,
         runTimeJarLoader = authJarLoader,
-        originalJarFolderName = null
+        originalJarFolderName = null,
+        tabFileExtension = null
     )
 
     val tabJarManager = TabJarManager(
@@ -81,9 +83,10 @@ class AppState {
             tabJarManager.deleteAllJars()
             tabJarManager.reset()
             val projectSettings =
-                FileManagement.loadProject(projectFile)?.let { loadedProject ->
-                    loadConfig(loadedProject)
-                }
+                FileManagement.loadProject(file = projectFile, setUserFeedback = globalFeedback::set)
+                    ?.let { loadedProject ->
+                        loadConfig(project = loadedProject)
+                    }
             if (projectSettings?.tabs != null) {
                 jarManagers.forEach {
                     it.refresh(printError = true)

--- a/src/main/kotlin/com/toasttab/pulseman/AppState.kt
+++ b/src/main/kotlin/com/toasttab/pulseman/AppState.kt
@@ -37,13 +37,17 @@ import com.toasttab.pulseman.state.TabHolder
 class AppState {
     val globalFeedback = GlobalFeedback()
 
-    val dependencyJars: JarManager<ClassInfo> = JarManager(
+    private val commonJarLoader = RunTimeJarLoader()
+    private val authJarLoader = RunTimeJarLoader(dependentJarLoader = commonJarLoader)
+
+    val commonJars: JarManager<ClassInfo> = JarManager(
         loadedClasses = LoadedClasses(
-            classFilters = emptyList()
+            classFilters = emptyList(),
+            runTimeJarLoader = commonJarLoader
         ),
         jarFolderName = DEPENDENCY_JAR_FOLDER,
         globalFeedback = globalFeedback,
-        runTimeJarLoader = RunTimeJarLoader(),
+        runTimeJarLoader = commonJarLoader,
         originalJarFolderName = null
     )
 
@@ -52,20 +56,21 @@ class AppState {
             classFilters = listOf(
                 // Add all the pulsar auth classes supported here
                 AuthClassFilter()
-            )
+            ),
+            runTimeJarLoader = authJarLoader
         ),
         jarFolderName = AUTH_JAR_FOLDER,
         globalFeedback = globalFeedback,
-        runTimeJarLoader = RunTimeJarLoader(dependentJarLoader = dependencyJars.runTimeJarLoader),
+        runTimeJarLoader = authJarLoader,
         originalJarFolderName = null
     )
 
     val tabJarManager = TabJarManager(
         globalFeedback = globalFeedback,
-        dependentJarLoader = authJars.runTimeJarLoader
+        dependentJarLoader = authJarLoader
     )
 
-    private val jarManagers = listOf(authJars, dependencyJars)
+    private val jarManagers = listOf(authJars, commonJars)
 
     val requestTabs = TabHolder(appState = this)
 

--- a/src/main/kotlin/com/toasttab/pulseman/AppStrings.kt
+++ b/src/main/kotlin/com/toasttab/pulseman/AppStrings.kt
@@ -37,6 +37,7 @@ object AppStrings {
     const val CLOSE_TAB = "Close tab"
     const val CLOSING = "Closing..."
     const val COLLAPSE = "Collapse"
+    const val COMMON = "Common"
     const val COMPILE = "Compile"
     const val COMPILING = "Compiling..."
     const val COMPILING_MESSAGE = "Compiling protobuf message"
@@ -92,7 +93,6 @@ object AppStrings {
     const val NO_VALID_CLASSES_LOADED = "No valid classes loaded"
     const val NO_TOPICS_FOUND = "No topics found"
     const val ON_TOPIC = "on topic"
-    const val OTHER = "Other"
     const val PROJECT_LOAD = "project load"
     const val PROJECT_FILE_DIALOG_TITLE = "Select Project File"
     const val PROTO_CLASS_NOT_SELECTED = "Proto class not selected"
@@ -139,4 +139,5 @@ object AppStrings {
     const val WAIT_SEND_TO_FINISH_ERROR = "Waiting to finish errored out"
     const val UNSAVED_CHANGES_DIALOG_MESSAGE = "Do you want to save your changes?"
     const val UNSAVED_CHANGES_DIALOG_TITLE = "Unsaved changes"
+    const val UNSELECTED = "Unselected"
 }

--- a/src/main/kotlin/com/toasttab/pulseman/entities/ClassInfo.kt
+++ b/src/main/kotlin/com/toasttab/pulseman/entities/ClassInfo.kt
@@ -16,7 +16,8 @@
 package com.toasttab.pulseman.entities
 
 /**
- * Interface that links a class to jar file
+ * Allows us to have generic class handling while the implementation can be more restrictive to the type of classes they
+ * handle
  */
 interface ClassInfo {
     val cls: Class<out Any>

--- a/src/main/kotlin/com/toasttab/pulseman/entities/ClassInfo.kt
+++ b/src/main/kotlin/com/toasttab/pulseman/entities/ClassInfo.kt
@@ -15,12 +15,9 @@
 
 package com.toasttab.pulseman.entities
 
-import java.io.File
-
 /**
  * Interface that links a class to jar file
  */
 interface ClassInfo {
-    val file: File
     val cls: Class<out Any>
 }

--- a/src/main/kotlin/com/toasttab/pulseman/entities/JarLoaderType.kt
+++ b/src/main/kotlin/com/toasttab/pulseman/entities/JarLoaderType.kt
@@ -1,7 +1,10 @@
 package com.toasttab.pulseman.entities
 
+/**
+ * Defines type of jar loader to use
+ */
 enum class JarLoaderType {
-    BASE,
-    GOOGLE_STANDARD,
-    PROTOKT
+    BASE, // Only loads the jars in the jar loader
+    GOOGLE_STANDARD, // Loads the google standard jars on top of the base jars
+    PROTOKT // Loads the protokt jars on top of the base jars
 }

--- a/src/main/kotlin/com/toasttab/pulseman/entities/JarLoaderType.kt
+++ b/src/main/kotlin/com/toasttab/pulseman/entities/JarLoaderType.kt
@@ -1,0 +1,7 @@
+package com.toasttab.pulseman.entities
+
+enum class JarLoaderType {
+    BASE,
+    GOOGLE_STANDARD,
+    PROTOKT
+}

--- a/src/main/kotlin/com/toasttab/pulseman/entities/ProjectSettings.kt
+++ b/src/main/kotlin/com/toasttab/pulseman/entities/ProjectSettings.kt
@@ -16,5 +16,5 @@
 package com.toasttab.pulseman.entities
 
 interface ProjectSettings {
-    fun toV3(): List<TabValuesV3>
+    fun toV3(): ProjectSettingsV3
 }

--- a/src/main/kotlin/com/toasttab/pulseman/entities/ProjectSettingsV1.kt
+++ b/src/main/kotlin/com/toasttab/pulseman/entities/ProjectSettingsV1.kt
@@ -28,28 +28,32 @@ import com.toasttab.pulseman.state.protocol.text.TextTabValuesV3
     level = DeprecationLevel.WARNING
 )
 data class ProjectSettingsV1(@Suppress("DEPRECATION") val tabs: List<TabValuesV1>) : ProjectSettings {
-    override fun toV3(): List<TabValuesV3> {
-        return tabs.map { tab ->
-            TabValuesV3(
-                tabName = tab.tabName,
-                topic = tab.topic,
-                serviceUrl = tab.serviceUrl,
-                selectedAuthClass = tab.selectedAuthClass,
-                authJsonParameters = tab.authJsonParameters,
-                propertyMap = tab.propertyMap,
-                serializationFormat = SerializationFormat.PROTOBUF,
-                protobufSettings = ProtobufTabValuesV3(
-                    code = tab.code,
-                    selectedClass = tab.selectedClassSend,
-                    convertValue = null,
-                    convertType = ConvertType.BASE64
-                ),
-                textSettings = TextTabValuesV3(
-                    text = null,
-                    selectedEncoding = null
-                ),
-                pulsarAdminURL = null
-            )
-        }
+    override fun toV3(): ProjectSettingsV3 {
+        return ProjectSettingsV3(
+            configVersion = ProjectSettingsV3.CURRENT_VERSION,
+            newJarFormatUsed = false,
+            tabs.map { tab ->
+                TabValuesV3(
+                    tabName = tab.tabName,
+                    topic = tab.topic,
+                    serviceUrl = tab.serviceUrl,
+                    selectedAuthClass = tab.selectedAuthClass,
+                    authJsonParameters = tab.authJsonParameters,
+                    propertyMap = tab.propertyMap,
+                    serializationFormat = SerializationFormat.PROTOBUF,
+                    protobufSettings = ProtobufTabValuesV3(
+                        code = tab.code,
+                        selectedClass = tab.selectedClassSend,
+                        convertValue = null,
+                        convertType = ConvertType.BASE64
+                    ),
+                    textSettings = TextTabValuesV3(
+                        text = null,
+                        selectedEncoding = null
+                    ),
+                    pulsarAdminURL = null
+                )
+            }
+        )
     }
 }

--- a/src/main/kotlin/com/toasttab/pulseman/entities/ProjectSettingsV1.kt
+++ b/src/main/kotlin/com/toasttab/pulseman/entities/ProjectSettingsV1.kt
@@ -51,7 +51,8 @@ data class ProjectSettingsV1(@Suppress("DEPRECATION") val tabs: List<TabValuesV1
                         text = null,
                         selectedEncoding = null
                     ),
-                    pulsarAdminURL = null
+                    pulsarAdminURL = null,
+                    tabExtension = null
                 )
             }
         )

--- a/src/main/kotlin/com/toasttab/pulseman/entities/ProjectSettingsV2.kt
+++ b/src/main/kotlin/com/toasttab/pulseman/entities/ProjectSettingsV2.kt
@@ -54,7 +54,8 @@ data class ProjectSettingsV2(
                         text = tab.textSettings?.text,
                         selectedEncoding = tab.textSettings?.selectedSendEncoding
                     ),
-                    pulsarAdminURL = null
+                    pulsarAdminURL = null,
+                    tabExtension = null
                 )
             }
         )

--- a/src/main/kotlin/com/toasttab/pulseman/entities/ProjectSettingsV2.kt
+++ b/src/main/kotlin/com/toasttab/pulseman/entities/ProjectSettingsV2.kt
@@ -31,28 +31,32 @@ data class ProjectSettingsV2(
     val configVersion: String,
     @Suppress("DEPRECATION") val tabs: List<TabValuesV2>
 ) : ProjectSettings {
-    override fun toV3(): List<TabValuesV3> {
-        return tabs.map { tab ->
-            TabValuesV3(
-                tabName = tab.tabName,
-                topic = tab.topic,
-                serviceUrl = tab.serviceUrl,
-                selectedAuthClass = tab.selectedAuthClass,
-                authJsonParameters = tab.authJsonParameters,
-                propertyMap = tab.propertyMap,
-                serializationFormat = tab.serializationFormat,
-                protobufSettings = ProtobufTabValuesV3(
-                    code = tab.protobufSettings?.code,
-                    selectedClass = tab.protobufSettings?.selectedClassSend,
-                    convertValue = null,
-                    convertType = ConvertType.BASE64
-                ),
-                textSettings = TextTabValuesV3(
-                    text = tab.textSettings?.text,
-                    selectedEncoding = tab.textSettings?.selectedSendEncoding
-                ),
-                pulsarAdminURL = null
-            )
-        }
+    override fun toV3(): ProjectSettingsV3 {
+        return ProjectSettingsV3(
+            configVersion = ProjectSettingsV3.CURRENT_VERSION,
+            newJarFormatUsed = false,
+            tabs = tabs.map { tab ->
+                TabValuesV3(
+                    tabName = tab.tabName,
+                    topic = tab.topic,
+                    serviceUrl = tab.serviceUrl,
+                    selectedAuthClass = tab.selectedAuthClass,
+                    authJsonParameters = tab.authJsonParameters,
+                    propertyMap = tab.propertyMap,
+                    serializationFormat = tab.serializationFormat,
+                    protobufSettings = ProtobufTabValuesV3(
+                        code = tab.protobufSettings?.code,
+                        selectedClass = tab.protobufSettings?.selectedClassSend,
+                        convertValue = null,
+                        convertType = ConvertType.BASE64
+                    ),
+                    textSettings = TextTabValuesV3(
+                        text = tab.textSettings?.text,
+                        selectedEncoding = tab.textSettings?.selectedSendEncoding
+                    ),
+                    pulsarAdminURL = null
+                )
+            }
+        )
     }
 }

--- a/src/main/kotlin/com/toasttab/pulseman/entities/ProjectSettingsV3.kt
+++ b/src/main/kotlin/com/toasttab/pulseman/entities/ProjectSettingsV3.kt
@@ -17,12 +17,13 @@ package com.toasttab.pulseman.entities
 
 data class ProjectSettingsV3(
     val configVersion: String,
+    val newJarFormatUsed: Boolean?, // This is a nullable field to support older versions of the project settings
     val tabs: List<TabValuesV3>
 ) : ProjectSettings {
 
-    override fun toV3(): List<TabValuesV3> = tabs
+    override fun toV3() = this
 
     companion object {
-        const val currentVersion = "3.0.0"
+        const val CURRENT_VERSION = "3.0.0"
     }
 }

--- a/src/main/kotlin/com/toasttab/pulseman/entities/SerializationFormat.kt
+++ b/src/main/kotlin/com/toasttab/pulseman/entities/SerializationFormat.kt
@@ -20,7 +20,7 @@ enum class SerializationFormat(val format: String) {
     PROTOBUF("Protobuf");
 
     companion object {
-        private val formatMapping = values().associateBy { it.format }
+        private val formatMapping = entries.associateBy { it.format }
 
         fun fromFormat(format: String): SerializationFormat = formatMapping[format]!!
     }

--- a/src/main/kotlin/com/toasttab/pulseman/entities/TabValuesV3.kt
+++ b/src/main/kotlin/com/toasttab/pulseman/entities/TabValuesV3.kt
@@ -31,5 +31,6 @@ data class TabValuesV3(
     val serializationFormat: SerializationFormat?,
     val protobufSettings: ProtobufTabValuesV3?,
     val textSettings: TextTabValuesV3?,
-    val pulsarAdminURL: String?
+    val pulsarAdminURL: String?,
+    val tabExtension: Int?
 )

--- a/src/main/kotlin/com/toasttab/pulseman/files/FileManagement.kt
+++ b/src/main/kotlin/com/toasttab/pulseman/files/FileManagement.kt
@@ -94,6 +94,11 @@ object FileManagement {
 
     fun deleteFile(file: File) {
         if (file.exists()) {
+            if (file.isDirectory) {
+                file.listFiles()?.forEach { child ->
+                    child.delete() // Not recursive, we don't have nested folders
+                }
+            }
             file.delete()
         }
     }

--- a/src/main/kotlin/com/toasttab/pulseman/files/FileManagement.kt
+++ b/src/main/kotlin/com/toasttab/pulseman/files/FileManagement.kt
@@ -148,9 +148,9 @@ object FileManagement {
         }
     }
 
-    fun loadProject(file: File): String? {
+    fun loadProject(file: File, setUserFeedback: (String) -> Unit): String? {
         FileWriter(lastConfigLoadedPath).use { fw -> fw.write(file.absolutePath) }
-        return zipManager.unzipProject(file)
+        return zipManager.unzipProject(zippedFile = file, setUserFeedback = setUserFeedback)
     }
 
     private fun getLastLoadedFile(): File? = File(lastConfigLoadedPath).let {

--- a/src/main/kotlin/com/toasttab/pulseman/files/ZipManagement.kt
+++ b/src/main/kotlin/com/toasttab/pulseman/files/ZipManagement.kt
@@ -15,6 +15,7 @@
 
 package com.toasttab.pulseman.files
 
+import com.toasttab.pulseman.AppStrings.EXCEPTION
 import com.toasttab.pulseman.files.FileManagement.loadedJars
 import java.io.BufferedInputStream
 import java.io.BufferedOutputStream
@@ -42,7 +43,7 @@ class ZipManagement(private val homeDirectory: String) {
             BufferedOutputStream(fos).use { bos ->
                 ZipOutputStream(bos).use { zos ->
                     // Save json file
-                    val jsonEntry = ZipEntry(projectTabsFileName)
+                    val jsonEntry = ZipEntry(PROJECT_TABS_FILE_NAME)
                     zos.putNextEntry(jsonEntry)
                     zos.write(tabsJson.toByteArray())
                     zos.closeEntry()
@@ -66,7 +67,7 @@ class ZipManagement(private val homeDirectory: String) {
 
     private fun savePath(file: File) = File(homeDirectory).toURI().relativize(file.toURI()).path
 
-    fun unzipProject(zippedFile: File): String? {
+    fun unzipProject(zippedFile: File, setUserFeedback: (String) -> Unit): String? {
         var projectJson: String? = null
         FileInputStream(zippedFile).use { fis ->
             BufferedInputStream(fis).use { bis ->
@@ -76,19 +77,22 @@ class ZipManagement(private val homeDirectory: String) {
                         if (!nextEntry.isDirectory && nextEntry.name !in skipFiles) {
                             val newFile = File("$homeDirectory${nextEntry.name}")
                             val parentFile: File? = newFile.parentFile
-                            if (parentFile?.exists() == true && isValidFolderPrefix(parentFile.name)) {
+                            if (parentFile?.exists() == false && isValidFolderPrefix(parentFile.name)) {
                                 parentFile.mkdirs()
                             }
-                            if (nextEntry.name == projectTabsFileName) {
+                            if (nextEntry.name == PROJECT_TABS_FILE_NAME) {
                                 projectJson = String(zis.readAllBytes())
                             } else {
-                                val newFile = File("$homeDirectory${nextEntry.name}")
-                                BufferedOutputStream(FileOutputStream(newFile)).use { bos ->
-                                    val bytesIn = ByteArray(1024)
-                                    var read: Int
-                                    while (zis.read(bytesIn).also { read = it } != -1) {
-                                        bos.write(bytesIn, 0, read)
+                                try {
+                                    BufferedOutputStream(FileOutputStream(newFile)).use { bos ->
+                                        val bytesIn = ByteArray(1024)
+                                        var read: Int
+                                        while (zis.read(bytesIn).also { read = it } != -1) {
+                                            bos.write(bytesIn, 0, read)
+                                        }
                                     }
+                                } catch (ex: Throwable) {
+                                    setUserFeedback("$EXCEPTION:\n$ex")
                                 }
                             }
                             zis.closeEntry()
@@ -102,8 +106,8 @@ class ZipManagement(private val homeDirectory: String) {
     private fun isValidFolderPrefix(folderName: String) = allowedFolder.any { folderName.startsWith(it) }
 
     companion object {
-        private const val projectTabsFileName = "project_tabs.json"
+        private const val PROJECT_TABS_FILE_NAME = "project_tabs.json"
         private val skipFiles = listOf(".DS_Store")
-        private val allowedFolder = listOf("message_jars")
+        private val allowedFolder = listOf("message_jars", "auth_jars", "dependency_jars")
     }
 }

--- a/src/main/kotlin/com/toasttab/pulseman/files/ZipManagement.kt
+++ b/src/main/kotlin/com/toasttab/pulseman/files/ZipManagement.kt
@@ -74,6 +74,11 @@ class ZipManagement(private val homeDirectory: String) {
                     while (true) {
                         val nextEntry = zis.nextEntry ?: return projectJson
                         if (!nextEntry.isDirectory && nextEntry.name !in skipFiles) {
+                            val newFile = File("$homeDirectory${nextEntry.name}")
+                            val parentFile: File? = newFile.parentFile
+                            if (parentFile?.exists() == true && isValidFolderPrefix(parentFile.name)) {
+                                parentFile.mkdirs()
+                            }
                             if (nextEntry.name == projectTabsFileName) {
                                 projectJson = String(zis.readAllBytes())
                             } else {
@@ -94,8 +99,11 @@ class ZipManagement(private val homeDirectory: String) {
         }
     }
 
+    private fun isValidFolderPrefix(folderName: String) = allowedFolder.any { folderName.startsWith(it) }
+
     companion object {
         private const val projectTabsFileName = "project_tabs.json"
         private val skipFiles = listOf(".DS_Store")
+        private val allowedFolder = listOf("message_jars")
     }
 }

--- a/src/main/kotlin/com/toasttab/pulseman/jars/JarManager.kt
+++ b/src/main/kotlin/com/toasttab/pulseman/jars/JarManager.kt
@@ -50,7 +50,8 @@ data class JarManager<T : ClassInfo>(
     private val globalFeedback: GlobalFeedback,
     private val jarFolderName: String,
     val runTimeJarLoader: RunTimeJarLoader,
-    val originalJarFolderName: String?
+    val originalJarFolderName: String?,
+    val tabFileExtension: Int?
 ) {
     private val originalJarFolderPath = originalJarFolderName?.let { "$it/" }
     private val originalJarFolder = originalJarFolderPath?.let { File("$APP_FOLDER_NAME$originalJarFolderPath") }

--- a/src/main/kotlin/com/toasttab/pulseman/jars/JarManager.kt
+++ b/src/main/kotlin/com/toasttab/pulseman/jars/JarManager.kt
@@ -68,13 +68,11 @@ data class JarManager<T : ClassInfo>(
     private fun addJar(jarFile: File, printError: Boolean) {
         checkForConflicts(file = jarFile, printError = printError)
         loadedJars.add(jarFile)
-        loadedClasses.addFile(jarFile)
         runTimeJarLoader.addJar(jarFile.toURI().toURL())
     }
 
     private fun removeJar(jarFile: File) {
         loadedJars.remove(jarFile)
-        loadedClasses.removeFile(jarFile)
         runTimeJarLoader.removeJar(jarFile.toURI().toURL())
     }
 
@@ -83,7 +81,6 @@ data class JarManager<T : ClassInfo>(
             runTimeJarLoader.removeJar(it.toURI().toURL())
         }
         loadedJars.clear()
-        loadedClasses.clear()
     }
 
     fun refresh(printError: Boolean) {
@@ -144,9 +141,9 @@ data class JarManager<T : ClassInfo>(
     ) {
         removeJar(jar)
         var feedback = "$REMOVED ${jar.path}"
-        if (selectedClass?.selected?.file == jar) {
-            feedback += "\n$DELETED_CLASS_FEEDBACK. ${selectedClass.selected?.cls?.name}"
-            selectedClass.selected = null
+        if (selectedClass?.selected?.cls?.protectionDomain?.codeSource?.location?.path == jar.path) {
+            feedback += "\n$DELETED_CLASS_FEEDBACK. ${selectedClass?.selected?.cls?.name}"
+            selectedClass?.selected = null
         }
         setUserFeedback(feedback)
         onChange()

--- a/src/main/kotlin/com/toasttab/pulseman/jars/SeperatedJars.kt
+++ b/src/main/kotlin/com/toasttab/pulseman/jars/SeperatedJars.kt
@@ -24,13 +24,13 @@ import java.net.URL
  */
 object SeperatedJars {
     // Gradle task copies and names these jars to the resource folder
-    private const val googleCommon = "proto-google-common-protos-original.jar"
-    private const val protoKTCommon = "proto-google-common-protos-protoKT.jar"
-    private const val protoKTCommonLite = "proto-google-common-protos-lite-protoKT.jar"
-    private const val commonResourceRoot = "common/"
+    private const val GOOGLE_COMMON = "proto-google-common-protos-original.jar"
+    private const val PROTOKT_COMMON = "proto-google-common-protos-protoKT.jar"
+    private const val PROTOKT_COMMON_LITE = "proto-google-common-protos-lite-protoKT.jar"
+    private const val COMMON_RESOURCE_ROOT = "common/"
 
-    private val googleJars = listOf(getJarURL(googleCommon))
-    private val protoKTJars = listOf(getJarURL(protoKTCommon), getJarURL(protoKTCommonLite))
+    private val googleJars = listOf(getJarURL(GOOGLE_COMMON))
+    private val protoKTJars = listOf(getJarURL(PROTOKT_COMMON), getJarURL(PROTOKT_COMMON_LITE))
 
     private fun getJarURL(resourcePath: String): URL {
         return try {
@@ -40,7 +40,7 @@ object SeperatedJars {
             resourcesDir.resolve(resourcePath).toURI().toURL()
         } catch (ex: Exception) {
             val contextClassLoader = Thread.currentThread().contextClassLoader!!
-            contextClassLoader.getResource("$commonResourceRoot$resourcePath")!!
+            contextClassLoader.getResource("$COMMON_RESOURCE_ROOT$resourcePath")!!
         }
     }
 

--- a/src/main/kotlin/com/toasttab/pulseman/jars/TabJarManager.kt
+++ b/src/main/kotlin/com/toasttab/pulseman/jars/TabJarManager.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2021 Toast Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.toasttab.pulseman.jars
+
+import com.toasttab.pulseman.files.FileManagement
+import com.toasttab.pulseman.pulsar.filters.protobuf.GeneratedMessageV3Filter
+import com.toasttab.pulseman.pulsar.filters.protobuf.KTMessageFilter
+import com.toasttab.pulseman.pulsar.handlers.PulsarMessageClassInfo
+import com.toasttab.pulseman.state.GlobalFeedback
+
+/**
+ * Manages the jars needed to serialize and deserialize messages for each tab
+ */
+data class TabJarManager(
+    private val globalFeedback: GlobalFeedback,
+    private val dependentJarLoader: RunTimeJarLoader? = null,
+    val jarManagers: MutableMap<Int, JarManager<PulsarMessageClassInfo>> = mutableMapOf()
+) {
+
+    fun add(tabNumber: Int, newJarFormat: Boolean): JarManager<PulsarMessageClassInfo> {
+        val runTimeJarLoader = RunTimeJarLoader(dependentJarLoader = dependentJarLoader)
+        return JarManager(
+            loadedClasses = LoadedClasses(
+                classFilters = listOf(
+                    // Add all the pulsar message formats supported here
+                    KTMessageFilter(runTimeJarLoader = runTimeJarLoader),
+                    GeneratedMessageV3Filter(runTimeJarLoader = runTimeJarLoader)
+                )
+            ),
+            jarFolderName = "${MESSAGE_JAR_FOLDER}_tab_$tabNumber",
+            globalFeedback = globalFeedback,
+            runTimeJarLoader = runTimeJarLoader,
+            originalJarFolderName = if (newJarFormat) null else MESSAGE_JAR_FOLDER
+        ).also {
+            jarManagers[tabNumber] = it
+            refresh(printError = true)
+        }
+    }
+
+    fun deleteAllJars() {
+        jarManagers.values.forEach { it.deleteAllJars() }
+    }
+
+    fun reset() {
+        // Search for folders beginning with MESSAGE_JAR_FOLDER and delete them
+        FileManagement.appFolder.listFiles()?.forEach {
+            if (it.isDirectory && it.name.startsWith("${MESSAGE_JAR_FOLDER}_")) {
+                FileManagement.deleteFile(it)
+            }
+        }
+        jarManagers.clear()
+    }
+
+    fun refresh(printError: Boolean) {
+        jarManagers.values.forEach { it.refresh(printError = printError) }
+    }
+
+    fun remove(tabNumber: Int) {
+        jarManagers.remove(tabNumber)
+    }
+
+    fun copyTab(fromTabNumber: Int, toTabNumber: Int) {
+        val fromJarManager = jarManagers[fromTabNumber] ?: return
+        val toJarManager = jarManagers[toTabNumber] ?: return
+        toJarManager.copyJars(jarFiles = fromJarManager.loadedJars, printError = true)
+    }
+
+    companion object {
+        private const val MESSAGE_JAR_FOLDER = "message_jars"
+    }
+}

--- a/src/main/kotlin/com/toasttab/pulseman/pulsar/Pulsar.kt
+++ b/src/main/kotlin/com/toasttab/pulseman/pulsar/Pulsar.kt
@@ -31,7 +31,7 @@ import com.toasttab.pulseman.AppStrings.NO_CLASS_GENERATED_TO_SEND
 import com.toasttab.pulseman.AppStrings.ON_TOPIC
 import com.toasttab.pulseman.AppStrings.SERVICE_URL_NOT_SET
 import com.toasttab.pulseman.AppStrings.TOPIC_NOT_SET
-import com.toasttab.pulseman.jars.RunTimeJarLoader.addJarsToClassLoader
+import com.toasttab.pulseman.jars.RunTimeJarLoader
 import com.toasttab.pulseman.state.PulsarSettings
 import org.apache.pulsar.client.api.Authentication
 import org.apache.pulsar.client.api.Consumer
@@ -53,10 +53,11 @@ import java.util.concurrent.TimeUnit
  */
 class Pulsar(
     private val pulsarSettings: PulsarSettings,
+    runTimeJarLoader: RunTimeJarLoader,
     private val setUserFeedback: (String) -> Unit
 ) {
     private var producer: Producer<ByteArray>? = null
-    private val pulsarAuth = PulsarAuth(pulsarSettings)
+    private val pulsarAuth = PulsarAuth(pulsarSettings = pulsarSettings, runTimeJarLoader = runTimeJarLoader)
 
     fun close() {
         try {
@@ -83,7 +84,6 @@ class Pulsar(
 
     private val pulsarClient by lazy {
         try {
-            addJarsToClassLoader()
             pulsarAuth.getAuthHandler()?.let { authHandler ->
                 authenticatedPulsarClient(authHandler)
             } ?: unAuthenticatedPulsarClient()

--- a/src/main/kotlin/com/toasttab/pulseman/pulsar/PulsarAuth.kt
+++ b/src/main/kotlin/com/toasttab/pulseman/pulsar/PulsarAuth.kt
@@ -15,6 +15,7 @@
 
 package com.toasttab.pulseman.pulsar
 
+import com.toasttab.pulseman.entities.JarLoaderType
 import com.toasttab.pulseman.jars.RunTimeJarLoader
 import com.toasttab.pulseman.state.PulsarSettings
 import org.apache.pulsar.client.api.Authentication
@@ -31,13 +32,13 @@ import org.apache.pulsar.client.api.EncodedAuthenticationParameterSupport
  * You will then need to provide your auth settings as a string, these will be passed to the **configure** method of the
  * EncodedAuthenticationParameterSupport interface at runtime.
  */
-class PulsarAuth(private val pulsarSettings: PulsarSettings) {
+class PulsarAuth(private val pulsarSettings: PulsarSettings, private val runTimeJarLoader: RunTimeJarLoader) {
     fun getAuthHandler(): Authentication? {
         val pulsarAuthClass = pulsarSettings.authSelector.selectedAuthClass.selected
             ?: return null
 
-        val authHandler = RunTimeJarLoader
-            .loader
+        val authHandler = runTimeJarLoader
+            .getJarLoader(jarLoaderType = JarLoaderType.BASE)
             .loadClass(pulsarAuthClass.cls.canonicalName)
             .getDeclaredConstructor()
             .newInstance() as Authentication

--- a/src/main/kotlin/com/toasttab/pulseman/pulsar/PulsarConfig.kt
+++ b/src/main/kotlin/com/toasttab/pulseman/pulsar/PulsarConfig.kt
@@ -17,6 +17,7 @@ package com.toasttab.pulseman.pulsar
 
 import com.toasttab.pulseman.AppStrings.EXCEPTION
 import com.toasttab.pulseman.AppStrings.FAILED_TO_RETRIEVE_TOPICS
+import com.toasttab.pulseman.jars.RunTimeJarLoader
 import com.toasttab.pulseman.state.PulsarSettings
 import org.apache.pulsar.client.admin.PulsarAdmin
 import java.util.concurrent.TimeUnit
@@ -25,14 +26,21 @@ import java.util.concurrent.TimeUnit
  * Handles connecting to pulsar admin and retrieving a list of topics, this is currently limited to unauthenticated
  * connections
  */
-class PulsarConfig(private val setUserFeedback: (String) -> Unit) {
+class PulsarConfig(
+    private val runTimeJarLoader: RunTimeJarLoader,
+    private val setUserFeedback: (String) -> Unit
+) {
     fun getTopics(pulsarUrl: String, pulsarSettings: PulsarSettings): List<String> {
         try {
             val builder = PulsarAdmin.builder()
 
-            PulsarAuth(pulsarSettings).getAuthHandler()?.let { authHandler ->
-                builder.authentication(authHandler)
-            }
+            PulsarAuth(
+                pulsarSettings = pulsarSettings,
+                runTimeJarLoader = runTimeJarLoader
+            ).getAuthHandler()
+                ?.let { authHandler ->
+                    builder.authentication(authHandler)
+                }
             builder
                 .serviceHttpUrl(pulsarUrl)
                 .connectionTimeout(30, TimeUnit.SECONDS)

--- a/src/main/kotlin/com/toasttab/pulseman/pulsar/filters/AuthClassFilter.kt
+++ b/src/main/kotlin/com/toasttab/pulseman/pulsar/filters/AuthClassFilter.kt
@@ -19,20 +19,19 @@ import com.toasttab.pulseman.pulsar.handlers.PulsarAuthHandler
 import org.apache.pulsar.client.api.Authentication
 import org.reflections.Reflections
 import org.reflections.scanners.Scanners.SubTypes
-import java.io.File
+import java.net.URL
 import java.net.URLClassLoader
-
 /**
  * Filters for classes that implement the Pulsar Authentication interface
  * https://pulsar.apache.org/api/client/org/apache/pulsar/client/api/Authentication.html)
  */
 class AuthClassFilter : ClassFilter<PulsarAuthHandler> {
-    override fun getClasses(file: File): Set<PulsarAuthHandler> {
-        val classLoader = URLClassLoader(arrayOf(file.toURI().toURL()))
+    override fun getClasses(url: URL): Set<PulsarAuthHandler> {
+        val classLoader = URLClassLoader(arrayOf(url))
         return Reflections(classLoader.urLs)
             .get(SubTypes.of(Authentication::class.java).asClass<Any>(classLoader))
             .filterIsInstance<Class<out Authentication>>()
-            .map { PulsarAuthHandler(it, file) }
+            .map { PulsarAuthHandler(it) }
             .toSet()
     }
 }

--- a/src/main/kotlin/com/toasttab/pulseman/pulsar/filters/protobuf/GeneratedMessageV3Filter.kt
+++ b/src/main/kotlin/com/toasttab/pulseman/pulsar/filters/protobuf/GeneratedMessageV3Filter.kt
@@ -22,7 +22,7 @@ import com.toasttab.pulseman.pulsar.handlers.PulsarMessageClassInfo
 import com.toasttab.pulseman.pulsar.handlers.protobuf.GeneratedMessageV3Handler
 import org.reflections.Reflections
 import org.reflections.scanners.Scanners
-import java.io.File
+import java.net.URL
 import java.net.URLClassLoader
 
 /**
@@ -30,12 +30,12 @@ import java.net.URLClassLoader
  * https://www.javadoc.io/static/com.google.protobuf/protobuf-java/3.5.1/com/google/protobuf/GeneratedMessageV3.html
  */
 class GeneratedMessageV3Filter(private val runTimeJarLoader: RunTimeJarLoader) : ClassFilter<PulsarMessageClassInfo> {
-    override fun getClasses(file: File): Set<GeneratedMessageV3Handler> {
-        val classLoader = URLClassLoader(arrayOf(file.toURI().toURL()))
+    override fun getClasses(url: URL): Set<GeneratedMessageV3Handler> {
+        val classLoader = URLClassLoader(arrayOf(url))
         return Reflections(classLoader.urLs)
             .get(Scanners.SubTypes.of(GeneratedMessageV3::class.java).asClass<Any>(classLoader))
             .filterIsInstance<Class<out GeneratedMessageV3>>()
-            .map { GeneratedMessageV3Handler(cls = it, file = file, runTimeJarLoader = runTimeJarLoader) }
+            .map { GeneratedMessageV3Handler(cls = it, runTimeJarLoader = runTimeJarLoader) }
             .toSet()
     }
 }

--- a/src/main/kotlin/com/toasttab/pulseman/pulsar/filters/protobuf/GeneratedMessageV3Filter.kt
+++ b/src/main/kotlin/com/toasttab/pulseman/pulsar/filters/protobuf/GeneratedMessageV3Filter.kt
@@ -16,6 +16,7 @@
 package com.toasttab.pulseman.pulsar.filters.protobuf
 
 import com.google.protobuf.GeneratedMessageV3
+import com.toasttab.pulseman.jars.RunTimeJarLoader
 import com.toasttab.pulseman.pulsar.filters.ClassFilter
 import com.toasttab.pulseman.pulsar.handlers.PulsarMessageClassInfo
 import com.toasttab.pulseman.pulsar.handlers.protobuf.GeneratedMessageV3Handler
@@ -28,13 +29,13 @@ import java.net.URLClassLoader
  * Filters for classes that implement the GeneratedMessageV3 protobuf message interface
  * https://www.javadoc.io/static/com.google.protobuf/protobuf-java/3.5.1/com/google/protobuf/GeneratedMessageV3.html
  */
-class GeneratedMessageV3Filter : ClassFilter<PulsarMessageClassInfo> {
+class GeneratedMessageV3Filter(private val runTimeJarLoader: RunTimeJarLoader) : ClassFilter<PulsarMessageClassInfo> {
     override fun getClasses(file: File): Set<GeneratedMessageV3Handler> {
         val classLoader = URLClassLoader(arrayOf(file.toURI().toURL()))
         return Reflections(classLoader.urLs)
             .get(Scanners.SubTypes.of(GeneratedMessageV3::class.java).asClass<Any>(classLoader))
             .filterIsInstance<Class<out GeneratedMessageV3>>()
-            .map { GeneratedMessageV3Handler(it, file) }
+            .map { GeneratedMessageV3Handler(cls = it, file = file, runTimeJarLoader = runTimeJarLoader) }
             .toSet()
     }
 }

--- a/src/main/kotlin/com/toasttab/pulseman/pulsar/filters/protobuf/KTMessageFilter.kt
+++ b/src/main/kotlin/com/toasttab/pulseman/pulsar/filters/protobuf/KTMessageFilter.kt
@@ -22,7 +22,7 @@ import com.toasttab.pulseman.pulsar.handlers.PulsarMessageClassInfo
 import com.toasttab.pulseman.pulsar.handlers.protobuf.KTMessageHandler
 import org.reflections.Reflections
 import org.reflections.scanners.Scanners
-import java.io.File
+import java.net.URL
 import java.net.URLClassLoader
 
 /**
@@ -30,12 +30,12 @@ import java.net.URLClassLoader
  * https://github.com/open-toast/protokt/blob/main/protokt-runtime/src/main/kotlin/com/toasttab/protokt/rt/KtMessage.kt
  */
 class KTMessageFilter(private val runTimeJarLoader: RunTimeJarLoader) : ClassFilter<PulsarMessageClassInfo> {
-    override fun getClasses(file: File): Set<KTMessageHandler> {
-        val classLoader = URLClassLoader(arrayOf(file.toURI().toURL()))
+    override fun getClasses(url: URL): Set<KTMessageHandler> {
+        val classLoader = URLClassLoader(arrayOf(url))
         return Reflections(classLoader.urLs)
             .get(Scanners.SubTypes.of(KtMessage::class.java).asClass<Any>(classLoader))
             .filterIsInstance<Class<out KtMessage>>()
-            .map { KTMessageHandler(cls = it, file = file, runTimeJarLoader = runTimeJarLoader) }
+            .map { KTMessageHandler(cls = it, runTimeJarLoader = runTimeJarLoader) }
             .toSet()
     }
 }

--- a/src/main/kotlin/com/toasttab/pulseman/pulsar/filters/protobuf/KTMessageFilter.kt
+++ b/src/main/kotlin/com/toasttab/pulseman/pulsar/filters/protobuf/KTMessageFilter.kt
@@ -16,6 +16,7 @@
 package com.toasttab.pulseman.pulsar.filters.protobuf
 
 import com.toasttab.protokt.rt.KtMessage
+import com.toasttab.pulseman.jars.RunTimeJarLoader
 import com.toasttab.pulseman.pulsar.filters.ClassFilter
 import com.toasttab.pulseman.pulsar.handlers.PulsarMessageClassInfo
 import com.toasttab.pulseman.pulsar.handlers.protobuf.KTMessageHandler
@@ -28,13 +29,13 @@ import java.net.URLClassLoader
  * Filters for classes that implement the KtMessage protobuf message interface
  * https://github.com/open-toast/protokt/blob/main/protokt-runtime/src/main/kotlin/com/toasttab/protokt/rt/KtMessage.kt
  */
-class KTMessageFilter : ClassFilter<PulsarMessageClassInfo> {
+class KTMessageFilter(private val runTimeJarLoader: RunTimeJarLoader) : ClassFilter<PulsarMessageClassInfo> {
     override fun getClasses(file: File): Set<KTMessageHandler> {
         val classLoader = URLClassLoader(arrayOf(file.toURI().toURL()))
         return Reflections(classLoader.urLs)
             .get(Scanners.SubTypes.of(KtMessage::class.java).asClass<Any>(classLoader))
             .filterIsInstance<Class<out KtMessage>>()
-            .map { KTMessageHandler(it, file) }
+            .map { KTMessageHandler(cls = it, file = file, runTimeJarLoader = runTimeJarLoader) }
             .toSet()
     }
 }

--- a/src/main/kotlin/com/toasttab/pulseman/pulsar/handlers/PulsarMessageClassInfo.kt
+++ b/src/main/kotlin/com/toasttab/pulseman/pulsar/handlers/PulsarMessageClassInfo.kt
@@ -17,6 +17,7 @@ package com.toasttab.pulseman.pulsar.handlers
 
 import com.toasttab.pulseman.entities.ClassInfo
 import com.toasttab.pulseman.jars.JarLoader
+import com.toasttab.pulseman.jars.RunTimeJarLoader
 import java.io.File
 
 /**
@@ -28,6 +29,7 @@ import java.io.File
 interface PulsarMessageClassInfo : PulsarMessage, ClassInfo {
     override val file: File
     override val cls: Class<out Any>
+    val runTimeJarLoader: RunTimeJarLoader
 
     /**
      * Generates a kotlin scripting code template for the class, this code will be used to create a pulsar message class

--- a/src/main/kotlin/com/toasttab/pulseman/pulsar/handlers/PulsarMessageClassInfo.kt
+++ b/src/main/kotlin/com/toasttab/pulseman/pulsar/handlers/PulsarMessageClassInfo.kt
@@ -18,7 +18,6 @@ package com.toasttab.pulseman.pulsar.handlers
 import com.toasttab.pulseman.entities.ClassInfo
 import com.toasttab.pulseman.jars.JarLoader
 import com.toasttab.pulseman.jars.RunTimeJarLoader
-import java.io.File
 
 /**
  * Defines an interface for serializing, deserializing and generating kotlin templates of a specific pulsar
@@ -27,7 +26,6 @@ import java.io.File
  * TODO make this interface more type safe
  */
 interface PulsarMessageClassInfo : PulsarMessage, ClassInfo {
-    override val file: File
     override val cls: Class<out Any>
     val runTimeJarLoader: RunTimeJarLoader
 

--- a/src/main/kotlin/com/toasttab/pulseman/pulsar/handlers/protobuf/GeneratedMessageV3Handler.kt
+++ b/src/main/kotlin/com/toasttab/pulseman/pulsar/handlers/protobuf/GeneratedMessageV3Handler.kt
@@ -22,11 +22,9 @@ import com.toasttab.pulseman.entities.JarLoaderType
 import com.toasttab.pulseman.jars.JarLoader
 import com.toasttab.pulseman.jars.RunTimeJarLoader
 import com.toasttab.pulseman.pulsar.handlers.PulsarMessageClassInfo
-import java.io.File
 
 data class GeneratedMessageV3Handler(
     override val cls: Class<out GeneratedMessageV3>,
-    override val file: File,
     override val runTimeJarLoader: RunTimeJarLoader
 ) : PulsarMessageClassInfo {
 

--- a/src/main/kotlin/com/toasttab/pulseman/pulsar/handlers/protobuf/GeneratedMessageV3Handler.kt
+++ b/src/main/kotlin/com/toasttab/pulseman/pulsar/handlers/protobuf/GeneratedMessageV3Handler.kt
@@ -18,13 +18,17 @@ package com.toasttab.pulseman.pulsar.handlers.protobuf
 import com.google.protobuf.GeneratedMessageV3
 import com.google.protobuf.util.JsonFormat
 import com.toasttab.pulseman.AppStrings.EXCEPTION
+import com.toasttab.pulseman.entities.JarLoaderType
 import com.toasttab.pulseman.jars.JarLoader
 import com.toasttab.pulseman.jars.RunTimeJarLoader
 import com.toasttab.pulseman.pulsar.handlers.PulsarMessageClassInfo
 import java.io.File
 
-data class GeneratedMessageV3Handler(override val cls: Class<out GeneratedMessageV3>, override val file: File) :
-    PulsarMessageClassInfo {
+data class GeneratedMessageV3Handler(
+    override val cls: Class<out GeneratedMessageV3>,
+    override val file: File,
+    override val runTimeJarLoader: RunTimeJarLoader
+) : PulsarMessageClassInfo {
 
     override fun serialize(cls: Any): ByteArray {
         val generatedMessageV3 = cls as GeneratedMessageV3
@@ -54,7 +58,7 @@ data class GeneratedMessageV3Handler(override val cls: Class<out GeneratedMessag
     }
 
     override fun getJarLoader(): JarLoader {
-        return RunTimeJarLoader.googleJarLoader
+        return runTimeJarLoader.getJarLoader(jarLoaderType = JarLoaderType.GOOGLE_STANDARD)
     }
 
     companion object {

--- a/src/main/kotlin/com/toasttab/pulseman/pulsar/handlers/protobuf/KTMessageHandler.kt
+++ b/src/main/kotlin/com/toasttab/pulseman/pulsar/handlers/protobuf/KTMessageHandler.kt
@@ -24,11 +24,9 @@ import com.toasttab.pulseman.jars.JarLoader
 import com.toasttab.pulseman.jars.RunTimeJarLoader
 import com.toasttab.pulseman.pulsar.handlers.DefaultMapper
 import com.toasttab.pulseman.pulsar.handlers.PulsarMessageClassInfo
-import java.io.File
 
 data class KTMessageHandler(
     override val cls: Class<out KtMessage>,
-    override val file: File,
     override val runTimeJarLoader: RunTimeJarLoader
 ) : PulsarMessageClassInfo {
 

--- a/src/main/kotlin/com/toasttab/pulseman/pulsar/handlers/protobuf/KTMessageHandler.kt
+++ b/src/main/kotlin/com/toasttab/pulseman/pulsar/handlers/protobuf/KTMessageHandler.kt
@@ -19,13 +19,18 @@ import com.toasttab.protokt.rt.KtDeserializer
 import com.toasttab.protokt.rt.KtMessage
 import com.toasttab.pulseman.AppStrings.EXCEPTION
 import com.toasttab.pulseman.AppStrings.TODO
+import com.toasttab.pulseman.entities.JarLoaderType
 import com.toasttab.pulseman.jars.JarLoader
 import com.toasttab.pulseman.jars.RunTimeJarLoader
 import com.toasttab.pulseman.pulsar.handlers.DefaultMapper
 import com.toasttab.pulseman.pulsar.handlers.PulsarMessageClassInfo
 import java.io.File
 
-data class KTMessageHandler(override val cls: Class<out KtMessage>, override val file: File) : PulsarMessageClassInfo {
+data class KTMessageHandler(
+    override val cls: Class<out KtMessage>,
+    override val file: File,
+    override val runTimeJarLoader: RunTimeJarLoader
+) : PulsarMessageClassInfo {
 
     override fun serialize(cls: Any): ByteArray {
         val ktMessage = cls as KtMessage
@@ -73,7 +78,7 @@ data class KTMessageHandler(override val cls: Class<out KtMessage>, override val
     }
 
     override fun getJarLoader(): JarLoader {
-        return RunTimeJarLoader.protoKTJarLoader
+        return runTimeJarLoader.getJarLoader(jarLoaderType = JarLoaderType.PROTOKT)
     }
 
     companion object {

--- a/src/main/kotlin/com/toasttab/pulseman/state/AuthSelector.kt
+++ b/src/main/kotlin/com/toasttab/pulseman/state/AuthSelector.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.mutableStateOf
 import com.toasttab.pulseman.AppStrings.ADD_CREDENTIAL_VALUES
 import com.toasttab.pulseman.AppStrings.SELECTED
+import com.toasttab.pulseman.AppStrings.UNSELECTED
 import com.toasttab.pulseman.entities.SingleSelection
 import com.toasttab.pulseman.entities.TabValuesV3
 import com.toasttab.pulseman.jars.JarManager
@@ -57,12 +58,14 @@ class AuthSelector(
 
     private fun onSelectedAuthClass(newValue: PulsarAuthHandler) {
         selectedAuthClass.selected =
-            if (selectedAuthClass.selected == newValue) {
+            if (selectedAuthClass.selected?.cls?.name == newValue.cls.name) {
+                setUserFeedback("$UNSELECTED ${newValue.cls.name}")
                 null
             } else {
+                setUserFeedback("$SELECTED ${newValue.cls.name}")
                 newValue
             }
-        setUserFeedback("$SELECTED ${newValue.cls.name}")
+
         onChange()
     }
 

--- a/src/main/kotlin/com/toasttab/pulseman/state/PulsarSettings.kt
+++ b/src/main/kotlin/com/toasttab/pulseman/state/PulsarSettings.kt
@@ -49,7 +49,8 @@ class PulsarSettings(
         settingsTopic = topic,
         pulsarAdminUrl = pulsarAdminUrl,
         setUserFeedback = setUserFeedback,
-        onChange = onChange
+        onChange = onChange,
+        runTimeJarLoader = appState.authJars.runTimeJarLoader
     )
 
     private val authJarManagement =

--- a/src/main/kotlin/com/toasttab/pulseman/state/PulsarSettings.kt
+++ b/src/main/kotlin/com/toasttab/pulseman/state/PulsarSettings.kt
@@ -22,7 +22,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.window.DialogState
 import com.toasttab.pulseman.AppState
 import com.toasttab.pulseman.AppStrings.AUTH
-import com.toasttab.pulseman.AppStrings.OTHER
+import com.toasttab.pulseman.AppStrings.COMMON
 import com.toasttab.pulseman.entities.TabValuesV3
 import com.toasttab.pulseman.view.propertyConfigurationUI
 import com.toasttab.pulseman.view.pulsarSettingsUI
@@ -53,10 +53,10 @@ class PulsarSettings(
         runTimeJarLoader = appState.authJars.runTimeJarLoader
     )
 
+    private val commonJarManagement =
+        JarManagement(appState.commonJars, null, setUserFeedback, onChange)
     private val authJarManagement =
         JarManagement(appState.authJars, authSelector.selectedAuthClass, setUserFeedback, onChange)
-    private val dependencyJarManagement =
-        JarManagement(appState.dependencyJars, null, setUserFeedback, onChange)
 
     private val showDiscover = mutableStateOf(false)
     private val showJarManagement = mutableStateOf(false)
@@ -65,8 +65,8 @@ class PulsarSettings(
 
     private val jarManagementTabs = JarManagementTabs(
         listOf(
-            Pair(AUTH, authJarManagement),
-            Pair(OTHER, dependencyJarManagement)
+            Pair(COMMON, commonJarManagement),
+            Pair(AUTH, authJarManagement)
         )
     )
 

--- a/src/main/kotlin/com/toasttab/pulseman/state/SerializationState.kt
+++ b/src/main/kotlin/com/toasttab/pulseman/state/SerializationState.kt
@@ -17,9 +17,10 @@ package com.toasttab.pulseman.state
 
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.runtime.Composable
-import com.toasttab.pulseman.AppState
 import com.toasttab.pulseman.entities.SerializationFormat
 import com.toasttab.pulseman.entities.TabValuesV3
+import com.toasttab.pulseman.jars.JarManager
+import com.toasttab.pulseman.pulsar.handlers.PulsarMessageClassInfo
 import com.toasttab.pulseman.state.protocol.protobuf.ProtobufState
 import com.toasttab.pulseman.state.protocol.text.TextState
 
@@ -28,7 +29,7 @@ import com.toasttab.pulseman.state.protocol.text.TextState
  * the ui for the currently selected format
  */
 class SerializationState(
-    appState: AppState,
+    pulsarMessageJars: JarManager<PulsarMessageClassInfo>,
     initialSettings: TabValuesV3? = null,
     pulsarSettings: PulsarSettings,
     setUserFeedback: (String) -> Unit,
@@ -40,7 +41,7 @@ class SerializationState(
     }
 
     val protobufState = ProtobufState(
-        appState = appState,
+        pulsarMessageJars = pulsarMessageJars,
         initialSettings = initialSettings,
         pulsarSettings = pulsarSettings,
         setUserFeedback = setUserFeedback,
@@ -50,6 +51,7 @@ class SerializationState(
     val textState = TextState(
         initialSettings = initialSettings,
         pulsarSettings = pulsarSettings,
+        runTimeJarLoader = pulsarMessageJars.runTimeJarLoader,
         setUserFeedback = setUserFeedback,
         onChange = onChange
     )

--- a/src/main/kotlin/com/toasttab/pulseman/state/TabHolder.kt
+++ b/src/main/kotlin/com/toasttab/pulseman/state/TabHolder.kt
@@ -72,7 +72,8 @@ class TabHolder(private val appState: AppState) {
                 close = ::close,
                 initialSettings = currentTab.tabValues().let { currentTabValues ->
                     currentTabValues.copy(
-                        tabName = currentTabValues.tabName + " - $COPY"
+                        tabName = currentTabValues.tabName + " - $COPY",
+                        tabExtension = null
                     )
                 },
                 newTab = true,

--- a/src/main/kotlin/com/toasttab/pulseman/state/TabHolder.kt
+++ b/src/main/kotlin/com/toasttab/pulseman/state/TabHolder.kt
@@ -34,7 +34,9 @@ class TabHolder(private val appState: AppState) {
             selection = selection,
             close = ::close,
             initialMessage = initialMessage,
-            newTab = true
+            newTab = true,
+            tabNumber = tabState.size + 1,
+            newJarFormat = true
         )
         tabState.add(tab)
         tab.activate()
@@ -48,14 +50,16 @@ class TabHolder(private val appState: AppState) {
         return tabState.any { it.unsavedChanges.value }
     }
 
-    fun load(tabSettings: List<TabValuesV3>) {
-        tabSettings.forEach {
+    fun load(tabSettings: List<TabValuesV3>, newJarFormat: Boolean) {
+        tabSettings.forEachIndexed { index, initialSettings ->
             val tab = TabState(
                 appState = appState,
                 selection = selection,
                 close = ::close,
-                initialSettings = it,
-                newTab = false
+                initialSettings = initialSettings,
+                newTab = false,
+                tabNumber = index + 1,
+                newJarFormat = newJarFormat
             )
             tabState.add(tab)
         }
@@ -73,9 +77,12 @@ class TabHolder(private val appState: AppState) {
                         tabName = currentTabValues.tabName + " - $COPY"
                     )
                 },
-                newTab = true
+                newTab = true,
+                tabNumber = tabState.size + 1,
+                newJarFormat = true
             )
             tabState.add(copiedTab)
+            appState.tabJarManager.copyTab(fromTabNumber = currentTab.tabNumber, toTabNumber = copiedTab.tabNumber)
             copiedTab.activate()
         }
     }

--- a/src/main/kotlin/com/toasttab/pulseman/state/TabHolder.kt
+++ b/src/main/kotlin/com/toasttab/pulseman/state/TabHolder.kt
@@ -35,7 +35,6 @@ class TabHolder(private val appState: AppState) {
             close = ::close,
             initialMessage = initialMessage,
             newTab = true,
-            tabNumber = tabState.size + 1,
             newJarFormat = true
         )
         tabState.add(tab)
@@ -51,14 +50,13 @@ class TabHolder(private val appState: AppState) {
     }
 
     fun load(tabSettings: List<TabValuesV3>, newJarFormat: Boolean) {
-        tabSettings.forEachIndexed { index, initialSettings ->
+        tabSettings.forEach { initialSettings ->
             val tab = TabState(
                 appState = appState,
                 selection = selection,
                 close = ::close,
                 initialSettings = initialSettings,
                 newTab = false,
-                tabNumber = index + 1,
                 newJarFormat = newJarFormat
             )
             tabState.add(tab)
@@ -78,11 +76,10 @@ class TabHolder(private val appState: AppState) {
                     )
                 },
                 newTab = true,
-                tabNumber = tabState.size + 1,
                 newJarFormat = true
             )
             tabState.add(copiedTab)
-            appState.tabJarManager.copyTab(fromTabNumber = currentTab.tabNumber, toTabNumber = copiedTab.tabNumber)
+            appState.tabJarManager.copyTab(fromTabID = currentTab.tabID, toTabID = copiedTab.tabID)
             copiedTab.activate()
         }
     }

--- a/src/main/kotlin/com/toasttab/pulseman/state/TabState.kt
+++ b/src/main/kotlin/com/toasttab/pulseman/state/TabState.kt
@@ -31,6 +31,7 @@ import com.toasttab.pulseman.entities.SerializationFormat
 import com.toasttab.pulseman.entities.SingleSelection
 import com.toasttab.pulseman.entities.TabValuesV3
 import com.toasttab.pulseman.view.tabUI
+import java.util.UUID
 
 class TabState(
     private val appState: AppState,
@@ -39,12 +40,12 @@ class TabState(
     val close: ((TabState) -> Unit),
     val unsavedChanges: MutableState<Boolean> = mutableStateOf(false),
     val initialSettings: TabValuesV3? = null,
-    val tabNumber: Int,
+    val tabID: UUID = UUID.randomUUID(),
     newTab: Boolean,
     initialMessage: String? = null,
     newJarFormat: Boolean
 ) {
-    private val pulsarMessageJars = appState.tabJarManager.add(tabNumber = tabNumber, newJarFormat = newJarFormat)
+    private val pulsarMessageJars = appState.tabJarManager.add(tabID = tabID, newJarFormat = newJarFormat)
 
     private var lastSavedTabValues: TabValuesV3? = initialSettings
 
@@ -83,15 +84,15 @@ class TabState(
         )
 
     private val serializationState = SerializationState(
+        pulsarMessageJars = pulsarMessageJars,
         initialSettings = initialSettings,
         pulsarSettings = pulsarSettings,
         setUserFeedback = userFeedback::set,
-        onChange = ::onChange,
-        pulsarMessageJars = pulsarMessageJars
+        onChange = ::onChange
     )
 
     fun cleanUp() {
-        appState.tabJarManager.remove(tabNumber = tabNumber)
+        appState.tabJarManager.remove(tabID = tabID)
         serializationState.cleanUp()
         userFeedback.close()
     }

--- a/src/main/kotlin/com/toasttab/pulseman/state/TabState.kt
+++ b/src/main/kotlin/com/toasttab/pulseman/state/TabState.kt
@@ -45,7 +45,11 @@ class TabState(
     initialMessage: String? = null,
     newJarFormat: Boolean
 ) {
-    private val pulsarMessageJars = appState.tabJarManager.add(tabID = tabID, newJarFormat = newJarFormat)
+    private val pulsarMessageJars = appState.tabJarManager.add(
+        tabID = tabID,
+        newJarFormat = newJarFormat,
+        tabFileExtension = initialSettings?.tabExtension
+    )
 
     private var lastSavedTabValues: TabValuesV3? = initialSettings
 
@@ -108,7 +112,8 @@ class TabState(
             serializationFormat = serializationFormat.value,
             protobufSettings = serializationState.protobufState.toProtobufTabValues(),
             textSettings = serializationState.textState.toTextTabValues(),
-            pulsarAdminURL = pulsarSettings.pulsarAdminUrl.value
+            pulsarAdminURL = pulsarSettings.pulsarAdminUrl.value,
+            tabExtension = pulsarMessageJars.tabFileExtension
         )
 
         if (save) {

--- a/src/main/kotlin/com/toasttab/pulseman/state/TopicSelector.kt
+++ b/src/main/kotlin/com/toasttab/pulseman/state/TopicSelector.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.snapshots.SnapshotStateList
 import com.toasttab.pulseman.AppStrings.SELECTED
 import com.toasttab.pulseman.entities.ButtonState
+import com.toasttab.pulseman.jars.RunTimeJarLoader
 import com.toasttab.pulseman.pulsar.PulsarConfig
 import com.toasttab.pulseman.view.topicSelectorUI
 import kotlinx.coroutines.CoroutineScope
@@ -33,10 +34,11 @@ class TopicSelector(
     private val settingsTopic: MutableState<String>,
     private val pulsarAdminUrl: MutableState<String>,
     private val showDiscover: MutableState<Boolean> = mutableStateOf(false),
-    val setUserFeedback: (String) -> Unit,
-    val onChange: () -> Unit
+    private val setUserFeedback: (String) -> Unit,
+    private val onChange: () -> Unit,
+    runTimeJarLoader: RunTimeJarLoader
 ) {
-    private val pulsarConfig = PulsarConfig(setUserFeedback)
+    private val pulsarConfig = PulsarConfig(runTimeJarLoader = runTimeJarLoader, setUserFeedback = setUserFeedback)
     private val topics: SnapshotStateList<String> = mutableStateListOf()
     private val topicRetrievalState = mutableStateOf(ButtonState.WAITING)
 

--- a/src/main/kotlin/com/toasttab/pulseman/state/protocol/protobuf/ProtobufState.kt
+++ b/src/main/kotlin/com/toasttab/pulseman/state/protocol/protobuf/ProtobufState.kt
@@ -20,11 +20,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.snapshots.SnapshotStateList
-import com.toasttab.pulseman.AppState
 import com.toasttab.pulseman.AppStrings
 import com.toasttab.pulseman.entities.ReceivedMessages
 import com.toasttab.pulseman.entities.TabValuesV3
+import com.toasttab.pulseman.jars.JarManager
 import com.toasttab.pulseman.pulsar.MessageHandlingClassImpl
+import com.toasttab.pulseman.pulsar.handlers.PulsarMessageClassInfo
 import com.toasttab.pulseman.state.JarManagement
 import com.toasttab.pulseman.state.JarManagementTabs
 import com.toasttab.pulseman.state.PulsarSettings
@@ -34,7 +35,7 @@ import com.toasttab.pulseman.view.protocol.protobuf.protobufUI
 import com.toasttab.pulseman.view.selectTabViewUI
 
 class ProtobufState(
-    appState: AppState,
+    pulsarMessageJars: JarManager<PulsarMessageClassInfo>,
     initialSettings: TabValuesV3? = null,
     pulsarSettings: PulsarSettings,
     setUserFeedback: (String) -> Unit,
@@ -47,7 +48,7 @@ class ProtobufState(
 
     private val protobufSelector =
         ProtobufMessageClassSelector(
-            pulsarMessageJars = appState.pulsarMessageJars,
+            pulsarMessageJars = pulsarMessageJars,
             setUserFeedback = setUserFeedback,
             onChange = onChange,
             initialSettings = initialSettings
@@ -55,10 +56,10 @@ class ProtobufState(
 
     private val protobufJarManagement =
         JarManagement(
-            appState.pulsarMessageJars,
-            protobufSelector.selectedClass,
-            setUserFeedback,
-            onChange
+            jars = pulsarMessageJars,
+            selectedClass = protobufSelector.selectedClass,
+            setUserFeedback = setUserFeedback,
+            onChange = onChange
         )
 
     private val protobufJarManagementTab = JarManagementTabs(
@@ -72,6 +73,7 @@ class ProtobufState(
         selectedClass = protobufSelector.selectedClass,
         pulsarSettings = pulsarSettings,
         initialSettings = initialSettings,
+        runTimeJarLoader = pulsarMessageJars.runTimeJarLoader,
         onChange = onChange
     )
 
@@ -86,7 +88,8 @@ class ProtobufState(
         setUserFeedback = setUserFeedback,
         pulsarSettings = pulsarSettings,
         receivedMessages = receivedMessages,
-        messageHandling = messageHandling
+        messageHandling = messageHandling,
+        runTimeJarLoader = pulsarMessageJars.runTimeJarLoader
     )
 
     private val convertProtoBufMessage = ConvertProtobufMessage(

--- a/src/main/kotlin/com/toasttab/pulseman/state/protocol/protobuf/SendProtobufMessage.kt
+++ b/src/main/kotlin/com/toasttab/pulseman/state/protocol/protobuf/SendProtobufMessage.kt
@@ -38,6 +38,7 @@ import com.toasttab.pulseman.entities.ButtonState
 import com.toasttab.pulseman.entities.CompileResult
 import com.toasttab.pulseman.entities.SingleSelection
 import com.toasttab.pulseman.entities.TabValuesV3
+import com.toasttab.pulseman.jars.RunTimeJarLoader
 import com.toasttab.pulseman.pulsar.Pulsar
 import com.toasttab.pulseman.pulsar.handlers.PulsarMessageClassInfo
 import com.toasttab.pulseman.scripting.KotlinScripting
@@ -58,6 +59,7 @@ import org.fife.ui.rsyntaxtextarea.SyntaxConstants
 import org.fife.ui.rtextarea.RTextScrollPane
 
 class SendProtobufMessage(
+    private val runTimeJarLoader: RunTimeJarLoader,
     val setUserFeedback: (String) -> Unit,
     val selectedClass: SingleSelection<PulsarMessageClassInfo>,
     val pulsarSettings: PulsarSettings,
@@ -129,7 +131,11 @@ class SendProtobufMessage(
     }
 
     private fun sendSinglePulsarMessage() {
-        pulsar = Pulsar(pulsarSettings, setUserFeedback)
+        pulsar = Pulsar(
+            pulsarSettings = pulsarSettings,
+            runTimeJarLoader = runTimeJarLoader,
+            setUserFeedback = setUserFeedback
+        )
         try {
             pulsar?.sendMessage(compileResult?.bytes)
         } catch (ex: Throwable) {
@@ -141,7 +147,11 @@ class SendProtobufMessage(
 
     private fun sendRepeatingPulsarMessages() {
         val job = createSendingMessageJob()
-        pulsar = Pulsar(pulsarSettings, setUserFeedback)
+        pulsar = Pulsar(
+            pulsarSettings = pulsarSettings,
+            runTimeJarLoader = runTimeJarLoader,
+            setUserFeedback = setUserFeedback
+        )
         var runs = 0
         var fails = 0
         var sleepTime = 0L
@@ -163,7 +173,12 @@ class SendProtobufMessage(
                         return
                     }
                     Thread.sleep(FAIL_SLEEP_TIME)
-                    pulsar = Pulsar(pulsarSettings, setUserFeedback) // Recreate producer so it can reconnect
+                    // Recreate producer so it can reconnect
+                    pulsar = Pulsar(
+                        pulsarSettings = pulsarSettings,
+                        runTimeJarLoader = runTimeJarLoader,
+                        setUserFeedback = setUserFeedback
+                    )
                     setUserFeedback("$FAILED_TO_SEND_MESSAGE. $RETRYING. $FAILS:$fails")
                 } else {
                     fails = 0

--- a/src/main/kotlin/com/toasttab/pulseman/state/protocol/text/SendText.kt
+++ b/src/main/kotlin/com/toasttab/pulseman/state/protocol/text/SendText.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.mutableStateOf
 import com.toasttab.pulseman.AppStrings.FAILED_TO_SEND_MESSAGE
 import com.toasttab.pulseman.entities.ButtonState
 import com.toasttab.pulseman.entities.TabValuesV3
+import com.toasttab.pulseman.jars.RunTimeJarLoader
 import com.toasttab.pulseman.pulsar.Pulsar
 import com.toasttab.pulseman.state.PulsarSettings
 import com.toasttab.pulseman.state.onStateChange
@@ -33,9 +34,9 @@ import kotlinx.coroutines.cancel
 import org.fife.ui.rsyntaxtextarea.SyntaxConstants
 import org.fife.ui.rtextarea.RTextScrollPane
 
-@Suppress("UNUSED_PARAMETER")
 class SendText(
     private val serializationTypeSelector: SerializationTypeSelector,
+    private val runTimeJarLoader: RunTimeJarLoader,
     val setUserFeedback: (String) -> Unit,
     val pulsarSettings: PulsarSettings,
     onChange: () -> Unit,
@@ -56,7 +57,11 @@ class SendText(
     }
 
     private fun sendPulsarMessage() {
-        val pulsar = Pulsar(pulsarSettings, setUserFeedback)
+        val pulsar = Pulsar(
+            pulsarSettings = pulsarSettings,
+            runTimeJarLoader = runTimeJarLoader,
+            setUserFeedback = setUserFeedback
+        )
         try {
             pulsar.sendMessage(serializationTypeSelector.selectedEncoding.selected?.serialize(textArea.text))
         } catch (ex: Throwable) {

--- a/src/main/kotlin/com/toasttab/pulseman/state/protocol/text/TextState.kt
+++ b/src/main/kotlin/com/toasttab/pulseman/state/protocol/text/TextState.kt
@@ -23,6 +23,7 @@ import androidx.compose.runtime.snapshots.SnapshotStateList
 import com.toasttab.pulseman.AppStrings
 import com.toasttab.pulseman.entities.ReceivedMessages
 import com.toasttab.pulseman.entities.TabValuesV3
+import com.toasttab.pulseman.jars.RunTimeJarLoader
 import com.toasttab.pulseman.pulsar.MessageHandlingImpl
 import com.toasttab.pulseman.state.PulsarSettings
 import com.toasttab.pulseman.state.ReceiveMessage
@@ -33,6 +34,7 @@ import com.toasttab.pulseman.view.selectTabViewUI
 class TextState(
     initialSettings: TabValuesV3? = null,
     pulsarSettings: PulsarSettings,
+    runTimeJarLoader: RunTimeJarLoader,
     setUserFeedback: (String) -> Unit,
     onChange: () -> Unit
 ) {
@@ -53,6 +55,7 @@ class TextState(
         setUserFeedback = setUserFeedback,
         pulsarSettings = pulsarSettings,
         initialSettings = initialSettings,
+        runTimeJarLoader = runTimeJarLoader,
         onChange = onChange
     )
 
@@ -68,7 +71,8 @@ class TextState(
         setUserFeedback = setUserFeedback,
         pulsarSettings = pulsarSettings,
         receivedMessages = receivedMessages,
-        messageHandling = messageHandling
+        messageHandling = messageHandling,
+        runTimeJarLoader = runTimeJarLoader
     )
 
     fun toTextTabValues() = TextTabValuesV3(

--- a/src/main/kotlin/com/toasttab/pulseman/view/AuthSelectorUI.kt
+++ b/src/main/kotlin/com/toasttab/pulseman/view/AuthSelectorUI.kt
@@ -162,7 +162,7 @@ fun authSelectorUI(
                                             onSelectedAuthClass(classInfo)
                                         }
                                     ) {
-                                        if (selectedAuthClass === classInfo) {
+                                        if (selectedAuthClass?.cls?.name == classInfo.cls.name) {
                                             Icon(Icons.Default.CheckCircle, SELECTED_CLASS)
                                         } else {
                                             Icon(Icons.Default.Clear, CLICK_TO_SELECT)

--- a/src/main/kotlin/com/toasttab/pulseman/view/JarManagementUI.kt
+++ b/src/main/kotlin/com/toasttab/pulseman/view/JarManagementUI.kt
@@ -96,7 +96,7 @@ fun jarManagementUI(
 
                         Text(
                             text = AnnotatedString(ADD_JAR),
-                            modifier = Modifier.weight(1F).align(Alignment.CenterVertically),
+                            modifier = Modifier.weight(1Fs).align(Alignment.CenterVertically),
                             maxLines = 1,
                             overflow = TextOverflow.Ellipsis
                         )

--- a/src/main/kotlin/com/toasttab/pulseman/view/JarManagementUI.kt
+++ b/src/main/kotlin/com/toasttab/pulseman/view/JarManagementUI.kt
@@ -96,7 +96,7 @@ fun jarManagementUI(
 
                         Text(
                             text = AnnotatedString(ADD_JAR),
-                            modifier = Modifier.weight(1Fs).align(Alignment.CenterVertically),
+                            modifier = Modifier.weight(1F).align(Alignment.CenterVertically),
                             maxLines = 1,
                             overflow = TextOverflow.Ellipsis
                         )

--- a/src/main/kotlin/com/toasttab/pulseman/view/MessageClassSelectorUI.kt
+++ b/src/main/kotlin/com/toasttab/pulseman/view/MessageClassSelectorUI.kt
@@ -132,7 +132,7 @@ fun messageClassSelectorUI(
                                     modifier = Modifier.weight(0.1F),
                                     onClick = { onSelectedClass(classInfo) }
                                 ) {
-                                    if (selectedClass === classInfo) {
+                                    if (selectedClass?.cls?.name == classInfo.cls.name) {
                                         Icon(Icons.Default.RadioButtonChecked, SELECTED_CLASS)
                                     } else {
                                         Icon(Icons.Default.RadioButtonUnchecked, CLICK_TO_SELECT)

--- a/src/test/kotlin/com/toasttab/pulseman/MultipleTypesPulsarMessage.kt
+++ b/src/test/kotlin/com/toasttab/pulseman/MultipleTypesPulsarMessage.kt
@@ -15,12 +15,18 @@
 
 package com.toasttab.pulseman
 
+import com.toasttab.pulseman.entities.JarLoaderType
 import com.toasttab.pulseman.jars.JarLoader
+import com.toasttab.pulseman.jars.RunTimeJarLoader
 import com.toasttab.pulseman.pulsar.handlers.DefaultMapper
 import com.toasttab.pulseman.pulsar.handlers.PulsarMessageClassInfo
 import java.io.File
 
-class MultipleTypesPulsarMessage(override val cls: Class<out MultipleTypes>, override val file: File) :
+class MultipleTypesPulsarMessage(
+    override val cls: Class<out MultipleTypes>,
+    override val file: File,
+    override val runTimeJarLoader: RunTimeJarLoader
+) :
     PulsarMessageClassInfo {
     override fun serialize(cls: Any): ByteArray = (cls as MultipleTypes).toBytes()
 
@@ -32,6 +38,6 @@ class MultipleTypesPulsarMessage(override val cls: Class<out MultipleTypes>, ove
     override fun generateClassTemplate(): String = "MultipleTypes()"
 
     override fun getJarLoader(): JarLoader {
-        return JarLoader(arrayOfNulls(0))
+        return runTimeJarLoader.getJarLoader(jarLoaderType = JarLoaderType.BASE)
     }
 }

--- a/src/test/kotlin/com/toasttab/pulseman/MultipleTypesPulsarMessage.kt
+++ b/src/test/kotlin/com/toasttab/pulseman/MultipleTypesPulsarMessage.kt
@@ -20,11 +20,9 @@ import com.toasttab.pulseman.jars.JarLoader
 import com.toasttab.pulseman.jars.RunTimeJarLoader
 import com.toasttab.pulseman.pulsar.handlers.DefaultMapper
 import com.toasttab.pulseman.pulsar.handlers.PulsarMessageClassInfo
-import java.io.File
 
 class MultipleTypesPulsarMessage(
     override val cls: Class<out MultipleTypes>,
-    override val file: File,
     override val runTimeJarLoader: RunTimeJarLoader
 ) :
     PulsarMessageClassInfo {

--- a/src/test/kotlin/com/toasttab/pulseman/jars/LoadedClassesTest.kt
+++ b/src/test/kotlin/com/toasttab/pulseman/jars/LoadedClassesTest.kt
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2021 Toast Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.toasttab.pulseman.jars
+
+import com.google.protobuf.GeneratedMessageV3
+import com.toasttab.protokt.rt.KtMessage
+import com.toasttab.pulseman.pulsar.filters.AuthClassFilter
+import com.toasttab.pulseman.pulsar.filters.protobuf.GeneratedMessageV3Filter
+import com.toasttab.pulseman.pulsar.filters.protobuf.KTMessageFilter
+import com.toasttab.pulseman.testjar.TestKtMessage
+import io.mockk.spyk
+import io.mockk.verify
+import org.apache.pulsar.client.api.Authentication
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.io.File
+import java.net.URL
+
+// If running these tests through an IDE
+// Run "./gradlew createTestJar" to generate test jars before running this test.
+// "./gradlew test" will run the createTestJar task first automatically
+class LoadedClassesTest {
+
+    private val jarFile = File("build/libs/test-class1.jar")
+    private val runTimeJarLoader = RunTimeJarLoader().also {
+        it.addJar(jarFile.toURI().toURL())
+    }
+
+    private val ktMessageFilter = spyk(KTMessageFilter(runTimeJarLoader = runTimeJarLoader))
+    private val generatedMessageV3Filter = GeneratedMessageV3Filter(runTimeJarLoader = runTimeJarLoader)
+    private val authClassFilter = AuthClassFilter()
+
+    private val loadedClassesKTMessageFilter = LoadedClasses(
+        classFilters = listOf(ktMessageFilter),
+        runTimeJarLoader = runTimeJarLoader
+    )
+    private val loadedClassesGeneratedMessageV3Filter = LoadedClasses(
+        classFilters = listOf(generatedMessageV3Filter),
+        runTimeJarLoader = runTimeJarLoader
+    )
+    private val loadedClassesAuthClassFilter = LoadedClasses(
+        classFilters = listOf(authClassFilter),
+        runTimeJarLoader = runTimeJarLoader
+    )
+    private val loadedClassesMessageFilters = LoadedClasses(
+        classFilters = listOf(ktMessageFilter, generatedMessageV3Filter),
+        runTimeJarLoader = runTimeJarLoader
+    )
+
+    @Test
+    fun `confirm KTMessageFilter successfully finds an entry`() {
+        val clsList = loadedClassesKTMessageFilter.filter("")
+        assertThat(clsList).hasSize(1)
+        assertThat(KtMessage::class.java.isAssignableFrom(clsList[0].cls)).isTrue
+    }
+
+    @Test
+    fun `confirm GeneratedMessageV3Filter successfully finds an entry`() {
+        val clsList = loadedClassesGeneratedMessageV3Filter.filter("")
+        assertThat(clsList).hasSize(1)
+        assertThat(GeneratedMessageV3::class.java.isAssignableFrom(clsList[0].cls)).isTrue
+    }
+
+    @Test
+    fun `confirm loading 2 message filters finds entries for both`() {
+        val clsList = loadedClassesMessageFilters.filter("")
+        assertThat(clsList).hasSize(2)
+        val entry1isKT = KtMessage::class.java.isAssignableFrom(clsList[0].cls)
+        val entry2isKT = KtMessage::class.java.isAssignableFrom(clsList[1].cls)
+        val entry1isV3 = GeneratedMessageV3::class.java.isAssignableFrom(clsList[0].cls)
+        val entry2isV3 = GeneratedMessageV3::class.java.isAssignableFrom(clsList[1].cls)
+        assertThat(entry1isKT.xor(entry2isKT)).isTrue
+        assertThat(entry1isV3.xor(entry2isV3)).isTrue
+    }
+
+    @Test
+    fun `confirm AuthClassFilter successfully finds an entry`() {
+        val clsList = loadedClassesAuthClassFilter.filter("")
+        assertThat(clsList).hasSize(1)
+        assertThat(Authentication::class.java.isAssignableFrom(clsList[0].cls)).isTrue
+    }
+
+    @Test
+    fun `confirm we dont reload all classes every time filter is called`() {
+        val jarLoader = RunTimeJarLoader()
+        jarLoader.addJar(jarFile.toURI().toURL())
+        val loadedClasses = LoadedClasses(
+            classFilters = listOf(ktMessageFilter),
+            runTimeJarLoader = jarLoader
+        )
+        // Filter once confirm queried the classes only once
+        loadedClasses.filter("")
+        verify(exactly = 1) {
+            ktMessageFilter.getClasses(any())
+        }
+
+        // Filter again confirm we don't query the classes again and use the cached map of classes
+        loadedClasses.filter("")
+        verify(exactly = 1) {
+            ktMessageFilter.getClasses(any())
+        }
+
+        // Add a fake url, so it has a new url list and needs to rebuild the classes
+        jarLoader.addJar(URL("file:jar1"))
+        loadedClasses.filter("")
+        verify(exactly = 3) {
+            ktMessageFilter.getClasses(any())
+        }
+
+        // Filter again confirm we don't query the classes again and use the cached map of classes
+        loadedClasses.filter("")
+        verify(exactly = 3) {
+            ktMessageFilter.getClasses(any())
+        }
+    }
+
+    @Test
+    fun `filtering by the name of a class returns the wanted entries`() {
+        val clsListFoundAll = loadedClassesMessageFilters.filter("")
+        assertThat(clsListFoundAll).hasSize(2)
+
+        val clsListFiltered = loadedClassesMessageFilters.filter("Test")
+        assertThat(clsListFiltered).hasSize(2)
+
+        val clsListFilter1 = loadedClassesMessageFilters.filter("TestK")
+        assertThat(clsListFilter1).hasSize(1)
+
+        val clsListFilterAll = loadedClassesMessageFilters.filter("TestKP")
+        assertThat(clsListFilterAll).hasSize(0)
+    }
+
+    @Test
+    fun `filtering works from any part of the class name`() {
+        val clsListFilter1 = loadedClassesMessageFilters.filter("stK")
+        assertThat(clsListFilter1).hasSize(1)
+    }
+
+    @Test
+    fun `getClass returns the needed class`() {
+        val className = TestKtMessage::class.qualifiedName!!
+        val foundClass = loadedClassesKTMessageFilter.getClass(className)
+        assertThat(foundClass?.cls?.name).isEqualTo(className)
+    }
+}

--- a/src/test/kotlin/com/toasttab/pulseman/jars/RunTimeJarLoaderTest.kt
+++ b/src/test/kotlin/com/toasttab/pulseman/jars/RunTimeJarLoaderTest.kt
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2021 Toast Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.toasttab.pulseman.jars
+
+import com.toasttab.pulseman.entities.JarLoaderType
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.net.URL
+
+class RunTimeJarLoaderTest {
+
+    @Test
+    fun `Adding and removing a jar from RunTimeJarLoader is done correctly`() {
+        val runTimeJarLoader = RunTimeJarLoader()
+        runTimeJarLoader.addJar(url1)
+        runTimeJarLoader.addJar(url2)
+
+        val expectedURLs = mutableListOf(url1, url2)
+        assertBaseUrls(runTimeJarLoader = runTimeJarLoader, expectedURLs = expectedURLs)
+        assertGoogleUrls(runTimeJarLoader = runTimeJarLoader, expectedURLs = expectedURLs)
+        assertProtoKTUrls(runTimeJarLoader = runTimeJarLoader, expectedURLs = expectedURLs)
+
+        runTimeJarLoader.removeJar(url2)
+
+        expectedURLs.remove(url2)
+        assertBaseUrls(runTimeJarLoader = runTimeJarLoader, expectedURLs = expectedURLs)
+        assertGoogleUrls(runTimeJarLoader = runTimeJarLoader, expectedURLs = expectedURLs)
+        assertProtoKTUrls(runTimeJarLoader = runTimeJarLoader, expectedURLs = expectedURLs)
+    }
+
+    @Test
+    fun `Removing a jar from a nested RunTimeJarLoader works as expected`() {
+        val runTimeJarLoader1 = RunTimeJarLoader()
+        runTimeJarLoader1.addJar(url1)
+
+        val runTimeJarLoader2 = RunTimeJarLoader(dependentJarLoader = runTimeJarLoader1)
+        runTimeJarLoader2.addJar(url2)
+
+        val runTimeJarLoader3 = RunTimeJarLoader(dependentJarLoader = runTimeJarLoader2)
+        runTimeJarLoader3.addJar(url3)
+
+        val expectedURLs1 = listOf(url1)
+        val expectedURLs2 = expectedURLs1 + url2
+        val expectedURLs3 = expectedURLs2 + url3
+
+        assertBaseUrls(runTimeJarLoader = runTimeJarLoader1, expectedURLs = expectedURLs1)
+        assertGoogleUrls(runTimeJarLoader = runTimeJarLoader1, expectedURLs = expectedURLs1)
+        assertProtoKTUrls(runTimeJarLoader = runTimeJarLoader1, expectedURLs = expectedURLs1)
+
+        assertBaseUrls(runTimeJarLoader = runTimeJarLoader2, expectedURLs = expectedURLs2)
+        assertGoogleUrls(runTimeJarLoader = runTimeJarLoader2, expectedURLs = expectedURLs2)
+        assertProtoKTUrls(runTimeJarLoader = runTimeJarLoader2, expectedURLs = expectedURLs2)
+
+        assertBaseUrls(runTimeJarLoader = runTimeJarLoader3, expectedURLs = expectedURLs3)
+        assertGoogleUrls(runTimeJarLoader = runTimeJarLoader3, expectedURLs = expectedURLs3)
+        assertProtoKTUrls(runTimeJarLoader = runTimeJarLoader3, expectedURLs = expectedURLs3)
+
+        runTimeJarLoader1.removeJar(url1)
+
+        val expectedURLs1AfterRemoval = emptyList<URL>()
+        val expectedURLs2AfterRemoval = listOf(url2)
+        val expectedURLs3AfterRemoval = expectedURLs2AfterRemoval + url3
+
+        assertBaseUrls(runTimeJarLoader = runTimeJarLoader1, expectedURLs = expectedURLs1AfterRemoval)
+        assertGoogleUrls(runTimeJarLoader = runTimeJarLoader1, expectedURLs = expectedURLs1AfterRemoval)
+        assertProtoKTUrls(runTimeJarLoader = runTimeJarLoader1, expectedURLs = expectedURLs1AfterRemoval)
+
+        assertBaseUrls(runTimeJarLoader = runTimeJarLoader2, expectedURLs = expectedURLs2AfterRemoval)
+        assertGoogleUrls(runTimeJarLoader = runTimeJarLoader2, expectedURLs = expectedURLs2AfterRemoval)
+        assertProtoKTUrls(runTimeJarLoader = runTimeJarLoader2, expectedURLs = expectedURLs2AfterRemoval)
+
+        assertBaseUrls(runTimeJarLoader = runTimeJarLoader3, expectedURLs = expectedURLs3AfterRemoval)
+        assertGoogleUrls(runTimeJarLoader = runTimeJarLoader3, expectedURLs = expectedURLs3AfterRemoval)
+        assertProtoKTUrls(runTimeJarLoader = runTimeJarLoader3, expectedURLs = expectedURLs3AfterRemoval)
+    }
+
+    private fun assertBaseUrls(runTimeJarLoader: RunTimeJarLoader, expectedURLs: List<URL>) {
+        val baseUrls = runTimeJarLoader.getJarLoader(jarLoaderType = JarLoaderType.BASE).urLs
+        assertThat(baseUrls).hasSize(expectedURLs.size)
+        assertContainsUrls(actualURLs = baseUrls, expectedURLs = expectedURLs)
+    }
+
+    private fun assertGoogleUrls(runTimeJarLoader: RunTimeJarLoader, expectedURLs: List<URL>) {
+        val googleUrls = runTimeJarLoader.getJarLoader(jarLoaderType = JarLoaderType.GOOGLE_STANDARD).urLs
+        assertThat(googleUrls).hasSize(expectedURLs.size + expectedGoogleURLs.size)
+        assertContainsUrls(actualURLs = googleUrls, expectedURLs = expectedURLs)
+        assertContainsUrlStrings(actualURLs = googleUrls, expectedURLs = expectedGoogleURLs)
+    }
+
+    private fun assertProtoKTUrls(runTimeJarLoader: RunTimeJarLoader, expectedURLs: List<URL>) {
+        val protoKTUrls = runTimeJarLoader.getJarLoader(jarLoaderType = JarLoaderType.PROTOKT).urLs
+        assertThat(protoKTUrls).hasSize(expectedURLs.size + expectedProtoKTURls.size)
+        assertContainsUrls(actualURLs = protoKTUrls, expectedURLs = expectedURLs)
+        assertContainsUrlStrings(actualURLs = protoKTUrls, expectedURLs = expectedProtoKTURls)
+    }
+
+    private fun assertContainsUrlStrings(actualURLs: Array<URL>, expectedURLs: List<String>) {
+        expectedURLs.forEach { expectedUrl ->
+            assertThat(actualURLs.singleOrNull { it.path.contains(expectedUrl) }).isNotNull()
+        }
+    }
+
+    private fun assertContainsUrls(actualURLs: Array<URL>, expectedURLs: List<URL>) {
+        expectedURLs.forEach { expectedUrl ->
+            assertThat(actualURLs).contains(expectedUrl)
+        }
+    }
+
+    companion object {
+        private val url1 = URL("file:jar1")
+        private val url2 = URL("file:jar2")
+        private val url3 = URL("file:jar3")
+
+        private const val GOOGLE_COMMON = "proto-google-common-protos-original.jar"
+        private const val PROTOKT_COMMON = "proto-google-common-protos-protoKT.jar"
+        private const val PROTOKT_COMMON_LITE = "proto-google-common-protos-lite-protoKT.jar"
+        private val expectedGoogleURLs = listOf(GOOGLE_COMMON)
+        private val expectedProtoKTURls = listOf(PROTOKT_COMMON, PROTOKT_COMMON_LITE)
+    }
+}

--- a/src/test/kotlin/com/toasttab/pulseman/pulsar/PulsarConfigITest.kt
+++ b/src/test/kotlin/com/toasttab/pulseman/pulsar/PulsarConfigITest.kt
@@ -16,6 +16,7 @@
 package com.toasttab.pulseman.pulsar
 
 import com.toasttab.pulseman.entities.SingleSelection
+import com.toasttab.pulseman.jars.RunTimeJarLoader
 import io.mockk.every
 import io.mockk.mockk
 import org.assertj.core.api.Assertions.assertThat
@@ -32,7 +33,7 @@ class PulsarConfigITest : PulsarITestSupport() {
 
     @Test
     fun `PulsarSettings retrieves a list of topics correctly`() {
-        val topicList = PulsarConfig {}.getTopics(
+        val topicList = PulsarConfig(runTimeJarLoader = RunTimeJarLoader()) {}.getTopics(
             pulsarUrl = pulsarContainer.httpServiceUrl,
             pulsarSettings = mockk {
                 every { authSelector } returns mockk {

--- a/src/test/kotlin/com/toasttab/pulseman/pulsar/PulsarITest.kt
+++ b/src/test/kotlin/com/toasttab/pulseman/pulsar/PulsarITest.kt
@@ -18,6 +18,7 @@ package com.toasttab.pulseman.pulsar
 import androidx.compose.runtime.mutableStateOf
 import com.toasttab.pulseman.MultipleTypes
 import com.toasttab.pulseman.entities.SingleSelection
+import com.toasttab.pulseman.jars.RunTimeJarLoader
 import com.toasttab.pulseman.state.PulsarSettings
 import io.mockk.every
 import io.mockk.mockk
@@ -39,6 +40,7 @@ import java.util.concurrent.TimeUnit
 class PulsarITest : PulsarITestSupport() {
     private lateinit var testTopic: String
     private lateinit var pulsarSettings: PulsarSettings
+    private lateinit var runTimeJarLoader: RunTimeJarLoader
 
     private val testPropertyString =
         """{
@@ -62,6 +64,7 @@ class PulsarITest : PulsarITestSupport() {
                 every { propertyMap() } returns testPropertyString
             }
         }
+        runTimeJarLoader = RunTimeJarLoader()
     }
 
     @Test
@@ -69,7 +72,7 @@ class PulsarITest : PulsarITestSupport() {
         val response = responseFuture(testTopic)
         val messageToSend = MultipleTypes()
 
-        Pulsar(pulsarSettings) {}.sendMessage(messageToSend.toBytes())
+        Pulsar(pulsarSettings, runTimeJarLoader) {}.sendMessage(messageToSend.toBytes())
 
         val message = response.get()
         val messageReceived = MultipleTypes.fromBytes(message.data)
@@ -84,7 +87,7 @@ class PulsarITest : PulsarITestSupport() {
         lateinit var receivedProperties: Map<String, String>
 
         val countDownLatch = CountDownLatch(1)
-        val subscribeFuture = Pulsar(pulsarSettings) {}.createNewConsumer {
+        val subscribeFuture = Pulsar(pulsarSettings, runTimeJarLoader) {}.createNewConsumer {
             receivedBytes = it.data
             receivedProperties = it.properties
             countDownLatch.countDown()

--- a/src/test/kotlin/com/toasttab/pulseman/pulsar/PulsarTextMessageITest.kt
+++ b/src/test/kotlin/com/toasttab/pulseman/pulsar/PulsarTextMessageITest.kt
@@ -18,6 +18,7 @@ package com.toasttab.pulseman.pulsar
 import androidx.compose.runtime.mutableStateOf
 import com.toasttab.pulseman.entities.CharacterSet
 import com.toasttab.pulseman.entities.SingleSelection
+import com.toasttab.pulseman.jars.RunTimeJarLoader
 import com.toasttab.pulseman.pulsar.handlers.text.TextHandler
 import com.toasttab.pulseman.state.PulsarSettings
 import io.mockk.every
@@ -35,6 +36,7 @@ import org.junit.jupiter.params.provider.MethodSource
 class PulsarTextMessageITest : PulsarITestSupport() {
     private lateinit var testTopic: String
     private lateinit var pulsarSettings: PulsarSettings
+    private lateinit var runTimeJarLoader: RunTimeJarLoader
 
     @BeforeAll
     fun init() {
@@ -50,6 +52,7 @@ class PulsarTextMessageITest : PulsarITestSupport() {
                 every { propertyMap() } returns testPropertyString
             }
         }
+        runTimeJarLoader = RunTimeJarLoader()
     }
 
     @ParameterizedTest(name = "characterSet:{0} input:{2} expectedOutput:{1}")
@@ -62,7 +65,7 @@ class PulsarTextMessageITest : PulsarITestSupport() {
         val response = responseFuture(testTopic)
         val textHandler = TextHandler(characterSet = characterSet)
 
-        Pulsar(pulsarSettings) {}.sendMessage(textHandler.serialize(input))
+        Pulsar(pulsarSettings, runTimeJarLoader) {}.sendMessage(textHandler.serialize(input))
 
         assertThat(response.get().data).isEqualTo(expectedOutput)
     }
@@ -77,7 +80,7 @@ class PulsarTextMessageITest : PulsarITestSupport() {
         val response = responseFuture(testTopic)
         val textHandler = TextHandler(characterSet = characterSet)
 
-        Pulsar(pulsarSettings) {}.sendMessage(input)
+        Pulsar(pulsarSettings, runTimeJarLoader) {}.sendMessage(input)
 
         val message = response.get()
         val messageReceived = textHandler.deserialize(message.data)

--- a/src/test/kotlin/com/toasttab/pulseman/scripting/KotlinScriptingTest.kt
+++ b/src/test/kotlin/com/toasttab/pulseman/scripting/KotlinScriptingTest.kt
@@ -18,6 +18,7 @@ package com.toasttab.pulseman.scripting
 import com.toasttab.pulseman.MultipleTypes
 import com.toasttab.pulseman.MultipleTypesPulsarMessage
 import com.toasttab.pulseman.entities.SingleSelection
+import com.toasttab.pulseman.jars.RunTimeJarLoader
 import com.toasttab.pulseman.pulsar.handlers.PulsarMessageClassInfo
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -27,7 +28,7 @@ class KotlinScriptingTest {
 
     @Test
     fun `Compiling a kotlin class works`() {
-        val pulsarMessage = MultipleTypesPulsarMessage(MultipleTypes::class.java, File("test"))
+        val pulsarMessage = MultipleTypesPulsarMessage(MultipleTypes::class.java, File("test"), RunTimeJarLoader())
         val selectedClass = SingleSelection<PulsarMessageClassInfo>().apply {
             selected = pulsarMessage
         }
@@ -48,7 +49,7 @@ class KotlinScriptingTest {
 
     @Test
     fun `Recompiling a kotlin class works`() {
-        val pulsarMessage = MultipleTypesPulsarMessage(MultipleTypes::class.java, File("test"))
+        val pulsarMessage = MultipleTypesPulsarMessage(MultipleTypes::class.java, File("test"), RunTimeJarLoader())
         val selectedClass = SingleSelection<PulsarMessageClassInfo>().apply {
             selected = pulsarMessage
         }

--- a/src/test/kotlin/com/toasttab/pulseman/scripting/KotlinScriptingTest.kt
+++ b/src/test/kotlin/com/toasttab/pulseman/scripting/KotlinScriptingTest.kt
@@ -22,13 +22,12 @@ import com.toasttab.pulseman.jars.RunTimeJarLoader
 import com.toasttab.pulseman.pulsar.handlers.PulsarMessageClassInfo
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import java.io.File
 
 class KotlinScriptingTest {
 
     @Test
     fun `Compiling a kotlin class works`() {
-        val pulsarMessage = MultipleTypesPulsarMessage(MultipleTypes::class.java, File("test"), RunTimeJarLoader())
+        val pulsarMessage = MultipleTypesPulsarMessage(MultipleTypes::class.java, RunTimeJarLoader())
         val selectedClass = SingleSelection<PulsarMessageClassInfo>().apply {
             selected = pulsarMessage
         }
@@ -49,7 +48,7 @@ class KotlinScriptingTest {
 
     @Test
     fun `Recompiling a kotlin class works`() {
-        val pulsarMessage = MultipleTypesPulsarMessage(MultipleTypes::class.java, File("test"), RunTimeJarLoader())
+        val pulsarMessage = MultipleTypesPulsarMessage(MultipleTypes::class.java, RunTimeJarLoader())
         val selectedClass = SingleSelection<PulsarMessageClassInfo>().apply {
             selected = pulsarMessage
         }

--- a/src/test/kotlin/com/toasttab/pulseman/testjar/TestAuthentication.kt
+++ b/src/test/kotlin/com/toasttab/pulseman/testjar/TestAuthentication.kt
@@ -13,14 +13,30 @@
  * limitations under the License.
  */
 
-package com.toasttab.pulseman.pulsar.handlers
+package com.toasttab.pulseman.testjar
 
-import com.toasttab.pulseman.entities.ClassInfo
 import org.apache.pulsar.client.api.Authentication
 
 /**
- * Links the Pulsar Authentication class to the jar file it came from
+ * Do not delete, this class is used to generate a JAR used in the LoadedClassesTest tests
+ *
+ * The createTestJar gradle task creates the JAR file.
  */
-data class PulsarAuthHandler(
-    override val cls: Class<out Authentication>
-) : ClassInfo
+class TestAuthentication : Authentication {
+    override fun close() {
+        TODO("Not yet implemented")
+    }
+
+    override fun getAuthMethodName(): String {
+        TODO("Not yet implemented")
+    }
+
+    @Deprecated("", ReplaceWith(""))
+    override fun configure(authParams: MutableMap<String, String>?) {
+        TODO("Not yet implemented")
+    }
+
+    override fun start() {
+        TODO("Not yet implemented")
+    }
+}

--- a/src/test/kotlin/com/toasttab/pulseman/testjar/TestGeneratedMessageV3.kt
+++ b/src/test/kotlin/com/toasttab/pulseman/testjar/TestGeneratedMessageV3.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2021 Toast Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.toasttab.pulseman.testjar
+
+import com.google.protobuf.GeneratedMessageV3
+import com.google.protobuf.Message
+
+/**
+ * Do not delete, this class is used to generate a JAR used in the LoadedClassesTest tests
+ *
+ * The createTestJar gradle task creates the JAR file.
+ */
+class TestGeneratedMessageV3() : GeneratedMessageV3() {
+    override fun getDefaultInstanceForType(): Message {
+        TODO("Not yet implemented")
+    }
+
+    override fun newBuilderForType(parent: BuilderParent?): Message.Builder {
+        TODO("Not yet implemented")
+    }
+
+    override fun newBuilderForType(): Message.Builder {
+        TODO("Not yet implemented")
+    }
+
+    override fun toBuilder(): Message.Builder {
+        TODO("Not yet implemented")
+    }
+
+    override fun internalGetFieldAccessorTable(): FieldAccessorTable {
+        TODO("Not yet implemented")
+    }
+}

--- a/src/test/kotlin/com/toasttab/pulseman/testjar/TestKtMessage.kt
+++ b/src/test/kotlin/com/toasttab/pulseman/testjar/TestKtMessage.kt
@@ -13,22 +13,18 @@
  * limitations under the License.
  */
 
-package com.toasttab.pulseman.pulsar.filters
+package com.toasttab.pulseman.testjar
 
-import com.toasttab.pulseman.entities.ClassInfo
-import java.net.URL
+import com.toasttab.protokt.rt.KtMessage
+import com.toasttab.protokt.rt.KtMessageSerializer
 
 /**
- * Defines an interface to filter a specific class type from a jar file
+ * Do not delete, this class is used to generate a JAR used in the LoadedClassesTest tests
  *
- * @param T The ClassInfo type that will be filtered
+ * The createTestJar gradle task creates the JAR file.
  */
-interface ClassFilter<T : ClassInfo> {
-    /**
-     * Should take the supplied jar file and return a set of filtered classes
-     *
-     * @param url The URL of the jar file to filter
-     * @return A set of T containing the list of filtered classes and their linked file.
-     */
-    fun getClasses(url: URL): Set<T>
+class TestKtMessage(override val messageSize: Int) : KtMessage {
+    override fun serialize(serializer: KtMessageSerializer) {
+        TODO("Not yet implemented")
+    }
 }


### PR DESCRIPTION
This is a massive refactor of the project.

The main aim of the changes is to have each tab be sandboxed and no longer have a single shared list of jars across all tabs.

Instead of having one `message_jar` folder to store all the serialisation jars, they will now be loaded to individual folders 
e.g `message_jars_tab_0`.

This mean thats the project size may ballon if you add the same jar to each tab. This can be gotten around by loading a jar to the common jar folder and making it available to the whole project.

The changes are as follow
- Have a jar loader per tab
- Implement dependent jar loaders where each jar loader will load the jars from its dependent jar loader, this will allow a tabs jar loader to also load a global jar loader.
- Instead of caching class lists we need to regenerate them each time as a dependent jar loader may have added or removed a jar.
- Added project conversion to update old projects to use this new tab format.

My hope is this will also make it easier to implement a gradle import mechanism as a follow up PR.